### PR TITLE
make fudge print usage instead of complaining about '' not being an file

### DIFF
--- a/fudge
+++ b/fudge
@@ -17,9 +17,6 @@ my $OUT = shift;
 if (!$OUT and $IN) {
     ($OUT = $IN) =~ s/\.t$/.$ME/ or $OUT .= ".$ME";
 }
-unless (-e $IN) {
-    die "$0: No such test file '$IN'\n";
-}
 unless ($ME and $IN and $OUT) {
 
     die <<"USAGE";
@@ -59,6 +56,9 @@ Usage: $0 [options] implname testfilename [fudgedtestfilename]
 
 
 USAGE
+}
+unless (-e $IN) {
+    die "$0: No such test file '$IN'\n";
 }
 
 if (-e $OUT) {


### PR DESCRIPTION
If you give no arguments to fudge it checks if the '' (empty filename) file exists and dies without printing the usage. I guess it should be that fudge prints the usage but not check if the ''-file exists. The following patch just moves the check for file-existance beneath the check for the command line arguments.

Greetings,
felher
