### PR TITLE
[fudge] return back compatibility with perl 5.8

### DIFF
--- a/fudge
+++ b/fudge
@@ -207,7 +207,7 @@ sub fudgeblock {
                 else {
                     my $does = join '|', keys %DOES;
                     next unless /^\s*($IS|$does)/;
-                    $numtests = $DOES{$1} // 1;
+                    $numtests = defined $DOES{$1}? $DOES{$1} : 1;
                 }
                 $PENDING--;
                 $_ = "{ " . $_ . " }";


### PR DESCRIPTION
don't use // (DOR) operator
