### PR TITLE
GCI - RT #76046

### DIFF
--- a/S03-sequence/basic.t
+++ b/S03-sequence/basic.t
@@ -3,7 +3,7 @@ use Test;
 
 # L<S03/List infix precedence/"the sequence operator">
 
-plan 124;
+plan 125;
 
 # single-term sequence
 
@@ -242,6 +242,9 @@ eval_dies_ok '1, 2, 3, ... 5', 'comma before sequence operator is caught';
 
 # RT #73268
 is ~(1...^*).munch(10), '1 2 3 4 5 6 7 8 9 10', 'RT #73268';
+
+# RT #76046
+is (1, 1, &[+] ... *).munch(10), '1 1 2 3 5 8 13 21 34 55', 'use &[+] on infix:<...> series';
 
 done;
 


### PR DESCRIPTION
Tried to understand the problem behind the bug, and to come up with a good test for [this bug](https://rt.perl.org/rt3//Public/Bug/Display.html?id=76046). I came up with

```
is (1, 1, &[+] ... *).munch(10), '1 1 2 3 5 8 13 21 34 55', 'use &[+] on infix:<...> series';
```

which I think would work to ensure that the issue doesn't come up again. Still, I'm aware that it doesn't really seem to be the best test, and being new to TDD, I'm really curious as to how it could be improved. Lots of help from #perl6, thanks :)
