### PR TITLE
tests for X::Does::TypeObject, X::Bind::ZenSlice and X::Role::Initialization

### DIFF
--- a/S32-exceptions/misc.t
+++ b/S32-exceptions/misc.t
@@ -120,6 +120,10 @@ throws_like 'augment class Any { }', X::Syntax::Augment::WithoutMonkeyTyping;
 throws_like 'use MONKEY_TYPING; augment role Positional { }', X::Syntax::Augment::Role;
 throws_like 'my $foo does &Int', X::Does::TypeObject;
 throws_like 'my $foo does &Int, &Bool', X::Does::TypeObject;
+throws_like 'role R { }; 99 but R("wrong");', X::Role::Initialization;
+throws_like 'role R { has $.x; has $.y }; 99 but R("wrong");', X::Role::Initialization;
+throws_like 'role R { }; 99 does R("wrong");', X::Role::Initialization;
+throws_like 'role R { has $.x; has $.y }; 99 does R("wrong");', X::Role::Initialization;
 
 throws_like 'sub f($a?, $b) { }', X::Parameter::WrongOrder,
     misplaced   => 'required',


### PR DESCRIPTION
implemented these in rakudo-nom in rakudo/rakudo#60
