### PR TITLE
The ~~ smart match requires Perl 5.10 

### DIFF
--- a/fudge
+++ b/fudge
@@ -33,7 +33,7 @@ if (@ARGV == 3) {
     $IN = shift; 
 } elsif (@ARGV == 2) {
     my $arg = shift;
-    if ($arg ~~ m/\.t$/) {
+    if ($arg =~ /\.t$/) {
         # test fudged
         $IN = $arg;
         $OUT = shift;


### PR DESCRIPTION
The ~~ smart match requires Perl 5.10.  Replace with just =~
