### PR TITLE
Add a test for smartmatching Signature and Signature

### DIFF
--- a/S03-smartmatch/signature-signature.t
+++ b/S03-smartmatch/signature-signature.t
@@ -1,0 +1,16 @@
+use v6;
+use Test;
+plan 5;
+
+#L<S03/Smart matching/Signature-signature>
+{
+	ok  (:(Str)      ~~ :(Str)),           'signature :(Str) is the same as :(Str)';
+	ok !(:(Str)      ~~ :(Int)),           'signature :(Str) is not the same as :(Int)';
+	ok  (:(Str, Int) ~~ :(Str, Int)),      'signature :(Str, Int) is the same as :(Str, Int)';
+	ok !(:(Str, Int) ~~ :(Int, Str)),      'signature :(Str, Int) is not the same as :(Int, Str)';
+	ok !(:(Str, Int) ~~ :(Str, Int, Str)), 'signature :(Str, Int) is not the same as :(Str, Int, Str)';
+}
+
+done;
+
+# vim: ft=perl6


### PR DESCRIPTION
Adding tests to check the missing functionality that was reported in
RT #82308: [TODO] [EASY] Implement signature-signature smartmatch.

This is my first time writing my own Perl 6 tests, and you are absolutely welcome to be critical.
