### PR TITLE
Rename classes for posterity (and to avoid name collisions)

### DIFF
--- a/S12-attributes/clone.t
+++ b/S12-attributes/clone.t
@@ -68,19 +68,19 @@ is($val2, 42, '... cloned object has proper attr value');
 # test cloning of array and hash attributes
 {
     # array
-    class A {
+    class ArrTest {
         has @.array;
     }
-    my $a1 = A.new(:array<a b>);
+    my $a1 = ArrTest.new(:array<a b>);
     my $a2 = $a1.clone(:array<c d>);
     is_deeply $a1.array, ['a', 'b'], 'original object has its original array';
     is_deeply $a2.array, ['c', 'd'], 'cloned object has the newly-provided array';
 
     # hash
-    class B {
+    class HshTest {
         has %.hash;
     }
-    my $b1 = B.new(hash=>{'a' => 'b'});
+    my $b1 = HshTest.new(hash=>{'a' => 'b'});
     my $b2 = $b1.clone(hash=>{'c' => 'd'});
     is_deeply $b1.hash, {'a' => 'b'}, 'original object has its original hash';
     is_deeply $b2.hash, {'c' => 'd'}, 'cloned object has the newly-provided hash';


### PR DESCRIPTION
This is a fix for my first pull request, in which I named the classes improperly.
