### PR TITLE
Use $*PROGRAM instead of $*PROGRAM_NAME

### DIFF
--- a/S02-magicals/progname.t
+++ b/S02-magicals/progname.t
@@ -4,8 +4,8 @@ use Test;
 
 plan 4;
 
-ok(PROCESS::<$PROGRAM_NAME> ~~ / t['/'|'\\']spec['/'|'\\']S02'-'magicals['/'|'\\']progname'.'\w+$/, "progname var matches test file path");
-ok($*PROGRAM_NAME ~~ / t['/'|'\\']spec['/'|'\\']S02'-'magicals['/'|'\\']progname'.'\w+$/, "progname var accessible as context var");
+ok(PROCESS::<$PROGRAM> ~~ / t['/'|'\\']spec['/'|'\\']S02'-'magicals['/'|'\\']progname'.'\w+$/, "progname var matches test file path");
+ok($*PROGRAM~~ / t['/'|'\\']spec['/'|'\\']S02'-'magicals['/'|'\\']progname'.'\w+$/, "progname var accessible as context var");
 
 # NOTE:
 # above is a junction hack for Unix and Win32 file

--- a/S02-types/deprecations.t
+++ b/S02-types/deprecations.t
@@ -18,7 +18,7 @@ my $line;
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from Any) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :exists adverb instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -29,7 +29,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from Any) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use the :delete adverb instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -39,7 +39,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method KeySet (from Any) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use 'SetHash' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -50,7 +50,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method KeyBag (from Any) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'BagHash' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -66,7 +66,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from Array) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :delete adverb with postcircumfix:<[ ]> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -82,7 +82,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from Bag) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :delete adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -98,7 +98,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from BagHash) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :delete adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -115,7 +115,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from Baggy) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use the :exists adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -126,7 +126,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from Baggy) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use the :exists adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -142,7 +142,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from Capture) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :exists adverb instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -158,7 +158,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method ucfirst (from Cool) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use 'tc' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -174,7 +174,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Sub Decrease (from GLOBAL) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use More instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -190,7 +190,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from EnumMap) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :exists adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -201,7 +201,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from EnumMap) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use the :exists adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -218,7 +218,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Sub ucfirst (from GLOBAL) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use 'tc' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -234,7 +234,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from Hash) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :delete adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -245,7 +245,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from Hash) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use the :delete adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -261,7 +261,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Sub Increase (from GLOBAL) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use Less instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -277,7 +277,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from List) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :exists adverb with postcircumfix:<[ ]> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -293,7 +293,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from Mix) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :delete adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -309,7 +309,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from MixHash) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :delete adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -326,7 +326,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Sub Decrease (from Order) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use More instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -343,7 +343,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Sub Increase (from Order) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use Less instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -359,7 +359,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from Set) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :delete adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -375,7 +375,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method delete (from SetHash) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use the :delete adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -392,7 +392,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from Setty) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use the :exists adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -403,7 +403,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method exists (from Setty) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use the :exists adverb with postcircumfix:<\{ }> instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -420,7 +420,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Sub eval (from GLOBAL) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'EVAL' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -431,7 +431,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method eval (from Cool) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'EVAL' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -448,7 +448,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*OS called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*DISTRO.name instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -465,7 +465,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*OSVER called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*DISTRO.version instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -482,7 +482,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*VM<name> called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*VM.name instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -499,7 +499,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*VM<config> called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*VM.config instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -516,7 +516,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*PERL<name> called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*PERL.name instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -533,7 +533,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*PERL<compiler><name> called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*PERL.compiler.name instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -550,7 +550,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*PERL<compiler><ver> called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*PERL.compiler.version instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -567,7 +567,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*PERL<compiler><release-number> called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*PERL.compiler.release instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -584,7 +584,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*PERL<compiler><build-date> called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*PERL.compiler.build-date instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -601,7 +601,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 \$*PERL<compiler><codename> called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use \$*PERL.compiler.codename instead.
 --------------------------------------------------------------------------------
 TEXT

--- a/S02-types/isDEPRECATED.t
+++ b/S02-types/isDEPRECATED.t
@@ -23,7 +23,7 @@ my $line;
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Sub a (from GLOBAL) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use something else instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -36,7 +36,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Sub awith (from GLOBAL) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'fnorkle' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -55,7 +55,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method new (from A) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use something else instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -67,7 +67,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method new (from Awith) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'Fnorkle.new' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -89,7 +89,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method new (from B) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use something else instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -102,7 +102,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method new (from Bwith) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'Borkle.new' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -123,7 +123,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method foo (from C) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use something else instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -136,7 +136,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method foo (from Cwith) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'bar' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -155,7 +155,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method foo (from D) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use something else instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -167,7 +167,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method foo (from Dwith) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'bar' instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -189,7 +189,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method foo (from E) called at:
-  $*PROGRAM_NAME, line $line
+  $*PROGRAM, line $line
 Please use something else instead.
 --------------------------------------------------------------------------------
 TEXT
@@ -202,7 +202,7 @@ TEXT
 Saw 1 call to deprecated code during execution.
 ================================================================================
 Method foo (from Ewith) called at:
-  $*PROGRAM_NAME, lines $line,{$line + 1}
+  $*PROGRAM, lines $line,{$line + 1}
 Please use 'bar' instead.
 --------------------------------------------------------------------------------
 TEXT

--- a/S16-filehandles/filetest.t
+++ b/S16-filehandles/filetest.t
@@ -25,11 +25,11 @@ lives_ok { 'non_existing_dir'.IO ~~ :d },
          'can :d-test against non-existing dir and live';
 ok !('non_existing_dir'.IO ~~ :d ),
          'can :d-test against non-existing dir and return false';
-ok $*PROGRAM_NAME.IO ~~ :f,  "~~:f returns true on files";
-ok $*PROGRAM_NAME.IO ~~ :e,  "~~:e returns true on files";
+ok $*PROGRAM.IO ~~ :f,  "~~:f returns true on files";
+ok $*PROGRAM.IO ~~ :e,  "~~:e returns true on files";
 ok 't'.IO ~~ :e,             "~~:e returns true on directories";
-ok $*PROGRAM_NAME.IO ~~ :r,  "~~:r returns true on readable files";
-ok $*PROGRAM_NAME.IO ~~ :w,  "~~:w returns true on writable files";
+ok $*PROGRAM.IO ~~ :r,  "~~:r returns true on readable files";
+ok $*PROGRAM.IO ~~ :w,  "~~:w returns true on writable files";
 
 if $*DISTRO.is-win {
   skip "win32 doesn't have ~~:x", 2;
@@ -59,11 +59,11 @@ ok not 'doesnotexist.t'.IO ~~ :x, "~~:x returns false on non-existent files";
 ok not 'doesnotexist.t'.IO ~~ :f, "~~:f returns false on non-existent files";
 
 #?niecza skip ".s NYI"
-ok($*PROGRAM_NAME.IO.s > 42,   "~~:s returns size on existent files");
+ok($*PROGRAM.IO.s > 42,   "~~:s returns size on existent files");
 
 nok "doesnotexist.t".IO ~~ :s, "~~:s returns false on non-existent files";
 
-nok $*PROGRAM_NAME.IO ~~ :z,   "~~:z returns false on existent files";
+nok $*PROGRAM.IO ~~ :z,   "~~:z returns false on existent files";
 nok "doesnotexist.t".IO ~~ :z, "~~:z returns false on non-existent files";
 nok "t".IO ~~ :z,              "~~:z returns false on directories";
 
@@ -109,9 +109,9 @@ unlink "empty_file";
 {
     sub f($) { return 8; }
 
-    is(f($*PROGRAM_NAME), 8, "f(...) works");
-    is(-f($*PROGRAM_NAME), -8, "- f(...) does not call the ~~:f filetest");
-    is(- f($*PROGRAM_NAME), -8, "- f(...) does not call the ~~:f filetest");
+    is(f($*PROGRAM), 8, "f(...) works");
+    is(-f($*PROGRAM), -8, "- f(...) does not call the ~~:f filetest");
+    is(- f($*PROGRAM), -8, "- f(...) does not call the ~~:f filetest");
 }
 
 


### PR DESCRIPTION
Bring roast up to speed with S28

The following files still need to be updated, but it's out of my level
of expertise:

```
S02-names/pseudo.t
S02-magicals/progname.t
```
