### PR TITLE
change part of underscore to dash

### DIFF
--- a/S12-meta/primitives.t
+++ b/S12-meta/primitives.t
@@ -7,15 +7,15 @@ plan 17;
 {
     my $union-type-checks = 0;
     my $union-find-method-calls = 0;
-    
+
     class UnionTypeHOW {
         has @!types;
-    
+
         submethod BUILD(:@!types) { }
-    
+
         method new_type(*@types) {
             my $how = self.new(:@types);
-            my $type = Metamodel::Primitives.create_type($how, 'Uninstantiable');
+            my $type = Metamodel::Primitives.create-type($how, 'Uninstantiable');
             $type
         }
 
@@ -25,31 +25,31 @@ plan 17;
 
         method compose($type) {
             # Set up type checking with cache.
-            Metamodel::Primitives.configure_type_checking($type,
+            Metamodel::Primitives.configure-type-checking($type,
                 [@!types, Any, Mu],
-                :authoritative, :call_accepts);
+                :authoritative, :call-accepts);
 
             # Steal methods of Any/Mu for our method cache.
             my %cache;
             for Any.^method_table.pairs, Mu.^method_table.pairs {
                 %cache{.key} //= .value;
             }
-            Metamodel::Primitives.install_method_cache($type, %cache);
-            
+            Metamodel::Primitives.install-method-cache($type, %cache);
+
             $type
         }
-    
+
         method type_check(Mu $, Mu \check) {
             $union-type-checks++;
             for @!types, Any, Mu {
-                return True if Metamodel::Primitives.is_type(check, $_);
+                return True if Metamodel::Primitives.is-type(check, $_);
             }
             return False;
         }
 
         method accepts_type(Mu $, Mu \check) {
             for @!types {
-                return True if Metamodel::Primitives.is_type(check, $_);
+                return True if Metamodel::Primitives.is-type(check, $_);
             }
             return False;
         }
@@ -84,7 +84,7 @@ plan 17;
     ok 4.2 ~~ $int-or-rat, 'Union type works with cache (4)';
     nok Str ~~ $int-or-rat, 'Union type works with cache (5)';
     nok 'w' ~~ $int-or-rat, 'Union type works with cache (6)';
-    
+
     is $union-type-checks, 0, 'Really did use type cache';
     is $union-find-method-calls, 0, 'Really did use method cache';
 }


### PR DESCRIPTION
There are some part that cann't be changed now, such as type_check, which is the Metamodel part. I think it need to be changed eventually.

There is also https://github.com/rakudo/rakudo/pull/338
