### PR TITLE
expand S16-io/newline.t tests to include Buf decoding

### DIFF
--- a/S16-io/newline.t
+++ b/S16-io/newline.t
@@ -1,17 +1,20 @@
 use v6;
 use Test;
 
-plan 3;
+plan 6;
 
 {
     use newline :lf;
     is "\n".encode('ascii'), Buf.new(0x0A), 'use newline :lf influences \n';
+    is Buf.new(0x0A).decode('ascii'), "\n", 'use newline :lf decodes to \n';
 }
 {
     use newline :cr;
     is "\n".encode('ascii'), Buf.new(0x0D), 'use newline :cr influences \n';
+    is Buf.new(0x0D).decode('ascii'), "\n", 'use newline :cr decodes to \n';
 }
 {
     use newline :crlf;
     is "\n".encode('ascii'), Buf.new(0xD, 0x0A), 'use newline :crlf influences \n';
+    is Buf.new(0xD, 0x0A).decode('ascii'), "\n", 'use newline :crlf decodes to \n';
 }


### PR DESCRIPTION
Tested on both ubuntu linux and Windows 7