### PR TITLE
fix S17-supply/syntax.t race condition

### DIFF
--- a/S06-operator-overloading/sub.t
+++ b/S06-operator-overloading/sub.t
@@ -2,7 +2,7 @@ use v6;
 
 use Test;
 
-plan 93;
+plan 96;
 
 =begin pod
 
@@ -289,12 +289,19 @@ Testing operator overloading subroutines
     sub circumfix:<<` `>>(*@args) { @args.join('-') }
     is `3, 4, "f"`, '3-4-f', 'slurpy circumfix:<<...>> works';
     is ` 3, 4, "f" `, '3-4-f', 'slurpy circumfix:<<...>> works, allows spaces';
+    is EVAL('` 3, 4, "f" `'),'3-4-f','lexically defined circumfix works inside EVAL';
 }
 
 {
     sub circumfix:<⌊ ⌋>($e) { $e.floor }
     is ⌊pi⌋, 3, 'circumfix with non-Latin1 bracketing characters';
     is ⌊ pi ⌋, 3, 'circumfix with non-Latin1 bracketing characters, allows spaces';
+}
+
+{
+    sub postcircumfix:<⌊ ⌋>($int,$arg) { $int + 1 }
+    is 1⌊1⌋,2, "sub postcircumfix:<...> works";
+    is EVAL(q|1⌊1⌋|),2,"lexically defined postcircumfix works inside EVAL";
 }
 
 # RT #86906

--- a/S06-operator-overloading/term.t
+++ b/S06-operator-overloading/term.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 9;
+plan 10;
 
 {
     package Foo {
@@ -15,6 +15,7 @@ plan 9;
     {
         my \term:<∞> = Inf;
         is ∞, Inf, "Can define \\term:<∞> as lexical variable";
+        is EVAL('∞'),Inf, "\\term:<∞> works in EVAL";
     }
     dies-ok { EVAL "∞" }, "my \\term:<∞> really is lexical";
 }

--- a/S12-meta/exporthow.t
+++ b/S12-meta/exporthow.t
@@ -1,7 +1,7 @@
 use v6;
 
 use Test;
-plan 8;
+plan 9;
 
 use lib '.';
 
@@ -28,6 +28,7 @@ throws-like { EVAL 'use t::spec::S12-meta::Supersede1;
     use t::spec::S12-meta::Declare;
     controller Home { }
     ok Home ~~ Controller, 'Type declared with new controller declarator got Controller role added';
+    EVAL(q|ok Home ~~ Controller|),'declarator works inside EVAL';
 }
 
 dies-ok { EVAL 'controller Fat { }' }, 'Imported declarators do not leak out of lexical scope';


### PR DESCRIPTION
This fixes a race condition where 
```perl6
$lock.protect({ $cv1.signal; $cv2.wait });
```
would run before
```perl6
 $lock.protect({ $cv1.wait });
```
which causes the test to hang forever. It only happened when I had TEST_JOBS set to >= to my cores. Not sure if this is a symptom of a greater bug or just something the test writer didn't consider.