### PR TITLE
Fix Win32 specific IO::Spec tests so they pass

### DIFF
--- a/S32-io/io-spec-win.t
+++ b/S32-io/io-spec-win.t
@@ -296,7 +296,7 @@ if $*DISTRO.name !~~ any(<mswin32 netware symbian os2 dos>) {
 }
 else {
 	# double check a couple of things to see if IO::Spec loaded correctly
-	is IO::Spec.devnull, 'nul', 'devnull is nul';
-	is IO::Spec.rootdir, '\\',  'rootdir is "\\"';
-	ok {.IO.d && .IO.w}.(IO::Spec.tmpdir), "tmpdir: {IO::Spec.tmpdir} is a writable directory";
+	is $*SPEC.devnull, 'nul', 'devnull is nul';
+	is $*SPEC.rootdir, '\\',  'rootdir is "\\"';
+	ok {.IO.d && .IO.w}.($*SPEC.tmpdir), "tmpdir: {$*SPEC.tmpdir} is a writable directory";
 }


### PR DESCRIPTION
I filed a confused [bug report][1] thinking these tests were not passing because of a failure of IO::Spec to delegate to IO::Spec::Win32. Later, I realized that invoking methods on IO::Spec is wrong, and one must use $*SPEC. This chunk of the the test file probably did not get exercised much.

[1]: https://rt.perl.org/Public/Bug/Display.html?id=126876