### PR TITLE
RFC: Add annotations to make roast deep-linkable

### DIFF
--- a/S03-operators/bit.t
+++ b/S03-operators/bit.t
@@ -11,6 +11,10 @@ plan 38;
 # numerics
 
 # L<S03/Changes to Perl 5 operators/Bitwise operators get a data type prefix>
+#| D<operators/bitwise/data type prefix>
+#| D<operators/V«+&»>
+#| D<operators/V«+|»>
+#| D<operators/V«+^»>
 {
 
   # numeric
@@ -20,6 +24,7 @@ plan 38;
   is( +^0xdead +& 0xbeef, 0x2042,    'numeric bitwise +^ and +& together' );
 
   # very large numbers
+  #| D<operators/bitwise/on large numbers>
   is 0xdeaddead0000deaddead0000dead +& 0xbeef0000beef0000beef0000beef,
      0x9ead0000000000009ead00009ead,
      'numeric bitwise +& of bigint';
@@ -36,6 +41,7 @@ plan 38;
   is 0x0123456789abcdef, 81985529216486895,
       'correct bit result with big enough hexadecimal (0x) literal';
 
+  #| D<operators/bitwise/on negative numbers>
   # Negative numbers.  These really need more tests for bigint vs sized natives
   # RT #122310
   is (-5 +& -2),(-6), "logical AND of two negative Int is twos complement";
@@ -43,6 +49,7 @@ plan 38;
   is (-7 +^ -6),( 3), "logical XOR of two negative Int is twos complement";
 
   # string
+  #| D<operators/bitwise/on strings>
   #?niecza 6 skip 'string bitops'
   is( 'a' ~& 'A',         'A',       'string bitwise ~& of "a" and "A"' );
   is( 'a' ~| 'b',         'c',       'string bitwise ~| of "a" and "b"' );
@@ -67,6 +74,8 @@ plan 38;
   is( "ok 20\n" ~| "ok \0\0\n", "ok 20\n",     'stringwise ~|, arbitrary string' );
 
   # bit shifting
+  #| D<operators/V«+<»>
+  #| D<operators/V«+>»>
   is( 32 +< 1,            64,     'shift one bit left' );
   is( 32 +> 1,            16,     'shift one bit right' );
   is( 257 +< 7,           32896,  'shift seven bits left' );
@@ -78,6 +87,7 @@ plan 38;
   is 0xdeaddead0000deaddead0000dead +> 4, 0xdeaddead0000deaddead0000dea, 'shift bigint 4 bits right';
 }
 
+#| D<operators/bitwise/cast negative floats to unsigned>
 {
   # Tests to see if you really can do casts negative floats to unsigned properly
   my $neg1 = -1.0.Num;
@@ -90,6 +100,8 @@ plan 38;
 }
 
 # RT #77232 - precedence of +< and +>
+#| D<operators/V«+<»/precedence>
+#| D<operators/V«+>»/precedence>
 {
   is( 48 + 0 +< 8, 48 + (0 +< 8), 'RT #77232 precedence of +<' );
   is( 48 + 0 +< 8, 48 + (0 +< 8), 'RT #77232 precedence of +>' );


### PR DESCRIPTION
Roast is now the specification for Perl 6, and is the language test-suite for Rakudo. However, currently roast and docs both refer to the synopsis, so the relationship is something like this:
![roast-01](https://cloud.githubusercontent.com/assets/8642/12285186/82cd04c6-b985-11e5-8fcf-b01961af4788.jpg)

I propose that we reverse the references; we make it so that you can deep-link to specific parts of Roast from the docs, and instead of Roast referring to Synopsis we should have Synopsis refer to Roast (though that is less important than docs).
![roast-02](https://cloud.githubusercontent.com/assets/8642/12285187/82cf0b9a-b985-11e5-89ad-50d3e67da889.jpg)

This PR uses (mis-uses?) the `D<>` pod6 reference as an example, but really the idea is to have something linkable. I think the filenames aren't fine-grained enough. The other side of this would be adding `L<>` entries to the docs. These wouldn't have to be visible links in the docs. Maybe like `L<roast:operators/++>` linking to `D<operators/++>`.

I'm very open to other syntaxes/notations for anchors & links.

The few things I'm hoping to get out of this in the short term:
* Doc coverage! Look for things in roast that have a D<> but there is no L<> to them from docs
* Make it so you can click and expand directly in the docs (inline) to see corresponding Roast examples. This is analogous to the "click to toggle source" js overlay from ruby-doc.org, but instead of deep linking into Rakudo, we'd deep-link into roast.

If this (or a variation we come up with) looks ok, I'd start annotating every roast file with the important concepts / syntax / etc that those tests define, ideally narrowed down to a specific block of assertions. I'd start with operators so I can get the docs side going as well and get a report of undocumented operators.