### PR TITLE
Test permutations(1) and (1,).permutations

### DIFF
--- a/S32-list/permutations.t
+++ b/S32-list/permutations.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 4;
+plan 8;
 
 # L<S32::Containers/List/=item permutations>
 
@@ -9,3 +9,9 @@ is permutations(3).list.perl, ((0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0
 
 is (1,).permutations.list.perl, ((1,),).perl, "permutations method on single element list";
 is permutations(1).list.perl, ((0,),).perl, "permutations function with 1 for its argument";
+
+is ().permutations.list.perl, ((),).perl, "permutations method on empty list";
+is permutations(0).list.perl, ((),).perl, "permutations function with 0 for its argument";
+
+is +().permutations, 1, "there is 1 permutation of empty list";
+is +permutations(0), 1, "there is 1 permutation with 0 values";

--- a/S32-list/permutations.t
+++ b/S32-list/permutations.t
@@ -1,8 +1,11 @@
 use Test;
 
-plan 2;
+plan 4;
 
 # L<S32::Containers/List/=item permutations>
 
 is (1, 2, 3).permutations.list.perl, ((1, 2, 3), (1, 3, 2), (2, 1, 3), (2, 3, 1), (3, 1, 2), (3, 2, 1)).perl, "permutations method";
 is permutations(3).list.perl, ((0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)).perl, "permutations function";
+
+is (1,).permutations.list.perl, ((1,),).perl, "permutations method on single element list";
+is permutations(1).list.perl, ((0,),).perl, "permutations function with 1 for its argument";


### PR DESCRIPTION
These are edge cases that regularly get overlooked

In fact this is a response to finding out that it has once again stopped working.

Do not accept until [Rakudo pull request #686](https://github.com/rakudo/rakudo/pull/686) or similar fix has been accepted.

The number of permutations of an empty list is known in math to be 1