### PR TITLE
Duration Improvements

### DIFF
--- a/S02-types/instants-and-durations.t
+++ b/S02-types/instants-and-durations.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 51;
+plan 113;
 
 # L<S02/Immutable types/'term now'>
 
@@ -73,6 +73,88 @@ throws-like { Instant.new(123) }, X::Cannot::New, 'Instant.new is illegal';
     cmp-ok  $d2, '~~', Real,      "Duration.new(__) ~~ Real";
     cmp-ok +$d1, '~~', Rational, "+Duration.new(__) ~~ Rational";
     cmp-ok +$d2, '~~', Rational, "+Duration.new(__) ~~ Rational";
+}
+
+# L<S02/Immutable types/'Numeric operations on durations return'>
+# #127339
+{
+    my (Duration $d1, Duration $d2, Int $i1, Int $i2) =
+        Duration.new(97), Duration.new(23), 97, 23;
+    my (Duration $d3, Duration $d4, Num $n3, Num $n4) =
+        Duration.new(97.67), Duration.new(23.73), 97.67e0, 23.73e0;
+
+    isa-ok $d1 + $i2, Duration, "Duration + Int ~~ Duration";
+    isa-ok $i1 + $d2, Duration, "Int + Duration ~~ Duration";
+    isa-ok $d1 + $d2, Duration, "Duration + Duration ~~ Duration";
+    isa-ok $d4 + $n4, Duration, "Duration + Num ~~ Duration";
+    isa-ok $n3 + $d4, Duration, "Num + Duration ~~ Duration";
+    isa-ok $d3 + $d4, Duration, "Duration + Duration ~~ Duration";
+
+    isa-ok $d1 - $i2, Duration, "Duration - Int ~~ Duration";
+    isa-ok $i1 - $d2, Duration, "Int - Duration ~~ Duration";
+    isa-ok $d1 - $d2, Duration, "Duration - Duration ~~ Duration";
+    isa-ok $d4 - $n4, Duration, "Duration - Num ~~ Duration";
+    isa-ok $n3 - $d4, Duration, "Num - Duration ~~ Duration";
+    isa-ok $d3 - $d4, Duration, "Duration - Duration ~~ Duration";
+
+    isa-ok $d1 * $i2, Duration, "Duration * Int ~~ Duration";
+    isa-ok $i1 * $d2, Duration, "Int * Duration ~~ Duration";
+    isa-ok $d1 * $d2, Duration, "Duration * Duration ~~ Duration";
+    isa-ok $d4 * $n4, Duration, "Duration * Num ~~ Duration";
+    isa-ok $n3 * $d4, Duration, "Num * Duration ~~ Duration";
+    isa-ok $d3 * $d4, Duration, "Duration * Duration ~~ Duration";
+
+    isa-ok $d1 / $i2, Duration, "Duration / Int ~~ Duration";
+    isa-ok $i1 / $d2, Duration, "Int / Duration ~~ Duration";
+    isa-ok $d3 / $n4, Duration, "Duration / Num ~~ Duration";
+    isa-ok $n3 / $d4, Duration, "Num / Duration ~~ Duration";
+    does-ok $d1 / $d2, Real,            "Duration / Duration ~~ Real";
+    cmp-ok  $d1 / $d2, '!~~', Duration, "Duration / Duration !~~ Duration";
+    does-ok $d3 / $d4, Real,            "Duration / Duration ~~ Real";
+    cmp-ok  $d3 / $d4, '!~~', Duration, "Duration / Duration !~~ Duration";
+
+    isa-ok $d1 % $i2, Duration, "Duration % Int ~~ Duration";
+    isa-ok $i1 % $d2, Duration, "Int % Duration ~~ Duration";
+    isa-ok $d1 % $d2, Duration, "Duration % Duration ~~ Duration";
+    isa-ok $d3 % $n4, Duration, "Duration % Num ~~ Duration";
+    isa-ok $n3 % $d4, Duration, "Num % Duration ~~ Duration";
+    isa-ok $d3 % $d4, Duration, "Duration % Duration ~~ Duration";
+
+
+    cmp-ok $d1 + $i2, '==', 120,    "Duration + Int == ?";
+    cmp-ok $i1 + $d2, '==', 120,    "Int + Duration == ?";
+    cmp-ok $d1 + $d2, '==', 120,    "Duration + Duration == ?";
+    cmp-ok $d3 + $n4, '==', 121.40, "Duration + Num == ?";
+    cmp-ok $n3 + $d4, '==', 121.40, "Num + Duration == ?";
+    cmp-ok $d3 + $d4, '==', 121.40, "Duration + Duration == ?";
+
+    cmp-ok $d1 - $i2, '==', 74,     "Duration - Int == ?";
+    cmp-ok $i1 - $d2, '==', 74,     "Int - Duration == ?";
+    cmp-ok $d1 - $d2, '==', 74,     "Duration - Duration == ?";
+    cmp-ok $d3 - $n4, '==', 73.940, "Duration - Num == ?";
+    cmp-ok $n3 - $d4, '==', 73.940, "Num - Duration == ?";
+    cmp-ok $d3 - $d4, '==', 73.940, "Duration - Duration == ?";
+
+    cmp-ok    $d1 * $i2, '==', 2231, "Duration * Int == ?";
+    cmp-ok    $i1 * $d2, '==', 2231, "Int * Duration == ?";
+    cmp-ok    $d1 * $d2, '==', 2231, "Duration * Duration == ?";
+    is-approx $d3 * $n4,       2317.70910000, "Duration * Num == ?";
+    is-approx $n3 * $d4,       2317.70910000, "Num * Duration == ?";
+    cmp-ok    $d3 * $d4, '==', 2317.70910000, "Duration * Duration == ?";
+
+    is-approx  $d1 / $i2, 4.21739130, "Duration / Int == ?";
+    is-approx  $i1 / $d2, 4.21739130, "Int / Duration == ?";
+    is-approx  $d1 / $d2, 4.21739130, "Duration / Duration == ?";
+    is-approx  $d3 / $n4, 4.11588706, "Duration / Num == ?";
+    is-approx  $n3 / $d4, 4.11588706, "Num / Duration == ?";
+    is-approx  $d3 / $d4, 4.11588706, "Duration / Duration == ?";
+
+    cmp-ok $d1 % $i2, '==', 5, "Duration % Int == ?";
+    cmp-ok $i1 % $d2, '==', 5, "Int % Duration == ?";
+    cmp-ok $d1 % $d2, '==', 5, "Duration % Duration == ?";
+    cmp-ok $d3 % $n4, '==', 2.75, "Duration % Num == ?";
+    cmp-ok $n3 % $d4, '==', 2.75, "Num % Duration == ?";
+    cmp-ok $d3 % $d4, '==', 2.75, "Duration % Duration == ?";
 }
 
 # See S32-temporal/DateTime-Instant-Duration.t for more.

--- a/S02-types/instants-and-durations.t
+++ b/S02-types/instants-and-durations.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 33;
+plan 35;
 
 # L<S02/Immutable types/'term now'>
 
@@ -42,11 +42,11 @@ throws-like { Instant.new(123) }, X::Cannot::New, 'Instant.new is illegal';
 }
 
 {
-    for (-2**63, -400.2, -33/7, -1, 0, 1, 33/7, 400.2, 2**32, ) -> $e {
-        my $i = Instant.from-posix($e, False);
-        is $i.perl.EVAL, $i, 'Instant round trips properly';
-        my $i = Instant.from-posix($e, True);
-        is $i.perl.EVAL, $i, 'Instant round trips properly';
+    for (-2**63, -400.2, -33/7, -1, 0, 1, 33/7, 400.2, 2**32, 915148800) -> $e {
+        for (True, False) -> $prefer-leap {
+            my $i = Instant.from-posix($e, $prefer-leap);
+            is $i.perl.EVAL, $i, 'Instant round trips properly';
+        }
     }
 }
 

--- a/S02-types/instants-and-durations.t
+++ b/S02-types/instants-and-durations.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 35;
+plan 51;
 
 # L<S02/Immutable types/'term now'>
 
@@ -48,6 +48,31 @@ throws-like { Instant.new(123) }, X::Cannot::New, 'Instant.new is illegal';
             is $i.perl.EVAL, $i, 'Instant round trips properly';
         }
     }
+}
+
+# L<S02/Immutable types/'these types behave like values'>
+
+{
+    my ($i1, $i2) = Instant.from-posix(500000.0e0), Instant.from-posix(1000000/2);
+    my ($d1, $d2) = Duration.new(500000.0e0), Duration.new(1000000/2);
+    for < eq == eqv === > -> $op {
+        cmp-ok $i1, $op, $i2, "Instant A $op Instant B";
+        cmp-ok $d1, $op, $d2, "Duration A $op Duration B";
+    }
+    cmp-ok $i1.WHICH, '===', $i2.WHICH, "InstantA.WHICH === InstantB.WHICH";
+    cmp-ok $d1.WHICH, '===', $d2.WHICH, "DurationA.WHICH === DurationB.WHICH";
+}
+
+# L<S02/Immutable types/'In numeric context a Duration happily returns a Rat'>
+
+{
+    my ($d1, $d2) = Duration.new(Int(5000000)), Duration.new(10000000e0/2);
+    cmp-ok  $d1, '~~', Numeric,   "Duration.new(__) ~~ Numeric";
+    cmp-ok  $d2, '~~', Numeric,   "Duration.new(__) ~~ Numeric";
+    cmp-ok  $d1, '~~', Real,      "Duration.new(__) ~~ Real";
+    cmp-ok  $d2, '~~', Real,      "Duration.new(__) ~~ Real";
+    cmp-ok +$d1, '~~', Rational, "+Duration.new(__) ~~ Rational";
+    cmp-ok +$d2, '~~', Rational, "+Duration.new(__) ~~ Rational";
 }
 
 # See S32-temporal/DateTime-Instant-Duration.t for more.


### PR DESCRIPTION
This is my first attempt to contribute something to p6; feel free to point out any errors/misunderstandings on my part, or further improvements; I am happy to incorporate suggestions and re-submit.

This adds a lot of test cases; in the long term, I can pare them down to the essentials, but for the moment and while the Duration behavior/implementation is in flux, i found them useful.

Description:
---
    Add additional tests for Duration; see RT #127339
    
    Also see corresponding PR/commits against rakudo/rakudo.
    
    Has tests to cover new functionality, and all tests pass.
    
    Still, I am new to Perl6, and look forward to one or more
    rounds of requested changes before this gets into Perl6.
---
    Move Duration and Instant closer to S02 spec.
    
    Duration and Instant should behave like value types.
    
    Also, Duration should become a Rat in numeric context.
---
    Fix warning and add a case for Instant round-trip
    
    Removes warning due to redefining "my $i".
    
    Adds Instant.from-posix(915148800) to the test values; this should
    mean 1998-12-31T23:59:60Z when $prefer-leap-second is False, but
    mean 1998-12-31T23:59:60Z 1999-01-01T00:00:00Z when it is True.