### PR TITLE
Rewrite test to avoid throws-like()

### DIFF
--- a/S06-advanced/wrap.t
+++ b/S06-advanced/wrap.t
@@ -12,7 +12,7 @@ use soft;
 # mutating wraps -- those should be "deep", as in not touching coderefs
 # but actually mutating how the coderef works.
 
-plan 85;
+plan 86;
 
 my @log;
 
@@ -166,7 +166,20 @@ is( functionB, 'xxx', "Wrap is now out of scope, should be back to normal." );
 
 # RT #70267
 # call to nextsame with nowhere to go
-throws-like '{nextsame}()', X::NoDispatcher, '{nextsame}() dies properly';
+# - Can't use throws-like() here due to difference in what error you get
+# - depending on version of Test.pm6: https://github.com/rakudo/rakudo/pull/743
+try {
+    my $msg = '{nextsame}() dies properly';
+    {nextsame}();
+    flunk $msg;
+    skip 'Code did not die, can not check exception', 1;
+    CATCH {
+        default {
+            pass $msg;
+            isa-ok $_, X::NoDispatcher, 'right exception type (X::NoDispatcher)';
+        }
+    }
+}
 
 # RT #66658
 #?niecza skip "undefined undefined"


### PR DESCRIPTION
This PR doesn't change the spectest functionally, it's just rewrites the way one test is done.

The use of `throws-like` makes the pass/fail of the test depend on the specifics of implementation of `throws-like`. Depending on whether subtest` that `throws-like` use is a multi, different exception type will be thrown.

See https://github.com/rakudo/rakudo/pull/743 for [more detailed explanation](https://github.com/rakudo/rakudo/pull/743#issuecomment-210489723).