### PR TITLE
Add from-loop tests

### DIFF
--- a/S32-list/seq.t
+++ b/S32-list/seq.t
@@ -128,19 +128,17 @@ is-deeply @searches[0].Array, @expected-searches, 'seq => array works 3';
 }
 
 {
-    ok Seq.from-loop({ 1 }).WHAT === Seq, 'from-loop(&body) returns a Seq';
-    my @a;
-    @a = Seq.from-loop({ 1 });
-    is @a.is-lazy, True, 'the Seq object is lazy';
+    my $a = Seq.from-loop({ 1 });
+    isa-ok $a, Seq, 'from-loop(&body) returns a Seq';
+    is $a.is-lazy, True, 'the Seq object is lazy';
 
-    ok Seq.from-loop({ 1 }, { state $count = 0; $count++ < 10 }).WHAT === Seq, 'from-loop(&body, &condition) returns a Seq';
-    @a = Seq.from-loop({ 1 }, { state $count = 0; $count++ < 10 });
-    is @a, (1) xx 10, 'from-loop(&body, &condition) terminates calling &body if &condition returns False';
+    $a = Seq.from-loop({ 1 }, { state $count = 0; $count++ < 10 });
+    isa-ok $a, Seq, 'from-loop(&body, &condition) returns a Seq';
+    is $a, (1) xx 10, 'from-loop(&body, &condition) terminates calling &body if &condition returns False';
 
     my $count = 0;
-    ok Seq.from-loop({ 1 }, { $count < 10 }, { $count++ }).WHAT === Seq, 'from-loop(&body, &condition, &afterward) returns a Seq';
-    $count = 0;
-    @a = Seq.from-loop({ 1 }, { $count < 10 }, { $count++ });
+    $a = Seq.from-loop({ 1 }, { $count < 10 }, { $count++ });
+    isa-ok $a, Seq, 'from-loop(&body, &condition, &afterward) returns a Seq';
+    is $a, (1) xx 10, 'from-loop(&body, &condition, &afterward) terminates calling &body if &condition returns False';
     is $count, 10, '&afterward is called after each call to &body.';
-    is @a, (1) xx 10, 'from-loop(&body, &condition, &afterward) terminates calling &body if &condition returns False';
 }

--- a/S32-list/seq.t
+++ b/S32-list/seq.t
@@ -130,7 +130,7 @@ is-deeply @searches[0].Array, @expected-searches, 'seq => array works 3';
 {
     my $a = Seq.from-loop({ 1 });
     isa-ok $a, Seq, 'from-loop(&body) returns a Seq';
-    is $a.is-lazy, True, 'the Seq object is lazy';
+    ok $a.is-lazy, 'the Seq object is lazy';
 
     $a = Seq.from-loop({ 1 }, { state $count = 0; $count++ < 10 });
     isa-ok $a, Seq, 'from-loop(&body, &condition) returns a Seq';

--- a/S32-list/seq.t
+++ b/S32-list/seq.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 28;
+plan 35;
 
 my @result = 1,2,3;
 
@@ -125,4 +125,22 @@ is-deeply @searches[0].Array, @expected-searches, 'seq => array works 3';
 
     throws-like { roundtripped.list }, X::Seq::Consumed,
         '.perl on an iterated sequence faithfully reproduces such a sequence';
+}
+
+{
+    my @a;
+    @a = Seq.from-loop({ 1 });
+    ok @a ~~ Seq, 'from-loop(&body) returns a Seq';
+    is @a.is-lazy, True, 'the Seq object is lazy';
+
+    @a = Seq.from-loop({ 1 }, { state $count = 0; $count++ < 10 });
+    ok @a ~~ Seq, 'from-loop(&body, &condition) returns a Seq';
+    is @a, (1) xx 10, 'from-loop(&body, &condition) terminates calling &body if &condition returns False';
+
+
+    my $count = 0;
+    @a = Seq.from-loop({ 1 }, { $count < 10 }, { $count++ });
+    ok @a ~~ Seq, 'from-loop(&body, &condition, &afterward) returns a Seq';
+    is $count, 10, '&afterward is called after each call to &body.';
+    is @a, (1) xx 10, 'from-loop(&body, &condition, &afterward) terminates calling &body if &condition returns False';
 }

--- a/S32-list/seq.t
+++ b/S32-list/seq.t
@@ -128,19 +128,19 @@ is-deeply @searches[0].Array, @expected-searches, 'seq => array works 3';
 }
 
 {
+    ok Seq.from-loop({ 1 }).WHAT === Seq, 'from-loop(&body) returns a Seq';
     my @a;
     @a = Seq.from-loop({ 1 });
-    ok @a ~~ Seq, 'from-loop(&body) returns a Seq';
     is @a.is-lazy, True, 'the Seq object is lazy';
 
+    ok Seq.from-loop({ 1 }, { state $count = 0; $count++ < 10 }).WHAT === Seq, 'from-loop(&body, &condition) returns a Seq';
     @a = Seq.from-loop({ 1 }, { state $count = 0; $count++ < 10 });
-    ok @a ~~ Seq, 'from-loop(&body, &condition) returns a Seq';
     is @a, (1) xx 10, 'from-loop(&body, &condition) terminates calling &body if &condition returns False';
 
-
     my $count = 0;
+    ok Seq.from-loop({ 1 }, { $count < 10 }, { $count++ }).WHAT === Seq, 'from-loop(&body, &condition, &afterward) returns a Seq';
+    $count = 0;
     @a = Seq.from-loop({ 1 }, { $count < 10 }, { $count++ });
-    ok @a ~~ Seq, 'from-loop(&body, &condition, &afterward) returns a Seq';
     is $count, 10, '&afterward is called after each call to &body.';
     is @a, (1) xx 10, 'from-loop(&body, &condition, &afterward) terminates calling &body if &condition returns False';
 }


### PR DESCRIPTION
Fix #114

I have added tests for the from-loop method according to the following page
https://doc.perl6.org/routine/from-loop#class_Seq

But I don't have very much confidence. Can anyone review this tests ?

The following is the results of the from-loop tests
```
not ok 29 - from-loop(&body) returns a Seq

# Failed test 'from-loop(&body) returns a Seq'
# at ./S32-list/seq.t line 133
ok 30 - the Seq object is lazy
not ok 31 - from-loop(&body, &condition) returns a Seq

# Failed test 'from-loop(&body, &condition) returns a Seq'
# at ./S32-list/seq.t line 137
ok 32 - from-loop(&body, &condition) terminates calling &body if &condition returns False
not ok 33 - from-loop(&body, &condition, &afterward) returns a Seq

# Failed test 'from-loop(&body, &condition, &afterward) returns a Seq'
# at ./S32-list/seq.t line 143
ok 34 - &afterward is called after each call to &body.
ok 35 - from-loop(&body, &condition, &afterward) terminates calling &body if &condition returns False
```