### PR TITLE
Tests for Proc.command and Proc.signal

### DIFF
--- a/S29-os/system.t
+++ b/S29-os/system.t
@@ -23,7 +23,7 @@ $res = shell("$*EXECUTABLE -e \"\"");
 ok($res, "shell() to an existing program does not die (and returns something true)");
 isa-ok($res, Proc, 'shell() returns a Proc');
 is($res.exitcode, 0, 'shell() exit code when successful is zero');
-is($res.signal, 0, 'run() signal after completion is zero');
+is($res.signal, 0, 'shell() signal after completion is zero');
 is($res.command, "$*EXECUTABLE -e \"\"", 'Proc returned from .run has correct command');
 
 $res = run("program_that_does_not_exist_ignore_this_error_please.exe");

--- a/S29-os/system.t
+++ b/S29-os/system.t
@@ -24,7 +24,7 @@ ok($res, "shell() to an existing program does not die (and returns something tru
 isa-ok($res, Proc, 'shell() returns a Proc');
 is($res.exitcode, 0, 'shell() exit code when successful is zero');
 is($res.signal, 0, 'shell() signal after completion is zero');
-is($res.command, "$*EXECUTABLE -e \"\"", 'Proc returned from .run has correct command');
+is($res.command, "$*EXECUTABLE -e \"\"", 'Proc returned from shell() has correct command');
 
 $res = run("program_that_does_not_exist_ignore_this_error_please.exe");
 ok(!$res, "run() to a nonexisting program does not die (and returns something false)");

--- a/S29-os/system.t
+++ b/S29-os/system.t
@@ -6,9 +6,9 @@ use Test;
 use Test::Util;
 
 # L<S29/"OS"/"=item run">
-# system is renamed to run, so link there. 
+# system is renamed to run, so link there.
 
-plan 31;
+plan 32;
 
 my $res;
 
@@ -16,6 +16,7 @@ $res = run($*EXECUTABLE,'-e', '');
 ok($res,"run() to an existing program does not die (and returns something true)");
 isa-ok($res, Proc, 'run() returns a Proc');
 is($res.exitcode, 0, 'run() exit code when successful is zero');
+is_deeply($res.command, [$*EXECUTABLE, '-e'], 'Proc returned from .run has correct command');
 
 $res = shell("$*EXECUTABLE -e \"\"");
 ok($res, "shell() to an existing program does not die (and returns something true)");

--- a/S29-os/system.t
+++ b/S29-os/system.t
@@ -8,7 +8,7 @@ use Test::Util;
 # L<S29/"OS"/"=item run">
 # system is renamed to run, so link there.
 
-plan 33;
+plan 35;
 
 my $res;
 
@@ -16,12 +16,14 @@ $res = run($*EXECUTABLE,'-e', '');
 ok($res,"run() to an existing program does not die (and returns something true)");
 isa-ok($res, Proc, 'run() returns a Proc');
 is($res.exitcode, 0, 'run() exit code when successful is zero');
+is($res.signal, 0, 'run() signal after completion is zero');
 is-deeply($res.command, [$*EXECUTABLE, '-e', ''], 'Proc returned from .run has correct command');
 
 $res = shell("$*EXECUTABLE -e \"\"");
 ok($res, "shell() to an existing program does not die (and returns something true)");
 isa-ok($res, Proc, 'shell() returns a Proc');
 is($res.exitcode, 0, 'shell() exit code when successful is zero');
+is($res.signal, 0, 'run() signal after completion is zero');
 is($res.command, "$*EXECUTABLE -e \"\"", 'Proc returned from .run has correct command');
 
 $res = run("program_that_does_not_exist_ignore_this_error_please.exe");

--- a/S29-os/system.t
+++ b/S29-os/system.t
@@ -8,7 +8,7 @@ use Test::Util;
 # L<S29/"OS"/"=item run">
 # system is renamed to run, so link there.
 
-plan 32;
+plan 33;
 
 my $res;
 
@@ -22,6 +22,7 @@ $res = shell("$*EXECUTABLE -e \"\"");
 ok($res, "shell() to an existing program does not die (and returns something true)");
 isa-ok($res, Proc, 'shell() returns a Proc');
 is($res.exitcode, 0, 'shell() exit code when successful is zero');
+is($res.command, "$*EXECUTABLE -e \"\"", 'Proc returned from .run has correct command');
 
 $res = run("program_that_does_not_exist_ignore_this_error_please.exe");
 ok(!$res, "run() to a nonexisting program does not die (and returns something false)");

--- a/S29-os/system.t
+++ b/S29-os/system.t
@@ -16,7 +16,7 @@ $res = run($*EXECUTABLE,'-e', '');
 ok($res,"run() to an existing program does not die (and returns something true)");
 isa-ok($res, Proc, 'run() returns a Proc');
 is($res.exitcode, 0, 'run() exit code when successful is zero');
-is_deeply($res.command, [$*EXECUTABLE, '-e'], 'Proc returned from .run has correct command');
+is-deeply($res.command, [$*EXECUTABLE, '-e', ''], 'Proc returned from .run has correct command');
 
 $res = shell("$*EXECUTABLE -e \"\"");
 ok($res, "shell() to an existing program does not die (and returns something true)");


### PR DESCRIPTION
Changes
===========
Add tests for `.command` and `.signal` methods for proc.


Proposed fix for https://github.com/perl6/roast/issues/166