### PR TITLE
Re-introduce the fixes for bag/mix symdif

### DIFF
--- a/S03-operators/bag.t
+++ b/S03-operators/bag.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 128;
+plan 130;
 
 sub showset($s) { $s.keys.sort.join(' ') }
 
@@ -172,36 +172,38 @@ ok bag(my @large_arr = ("a"...*)[^50000]), "... a large array goes into a bar - 
     # my $kb = BagHash.new(<blood love love>);
     my @d;
     
-    is showkv([⊎] @d), showkv(∅), "Bag sum reduce works on nothing";
-    is showkv([⊎] $s), showkv($s.Bag), "Bag sum reduce works on one set";
-    is showkv([⊎] $s, $b), showkv({ blood => 3, rhetoric => 1, love => 3 }), "Bag sum reduce works on two sets";
-    is showkv([⊎] $s, $b, $kb), showkv({ blood => 4, rhetoric => 1, love => 5 }), "Bag sum reduce works on three sets";
+    is ([⊎] @d), (∅), "Bag sum reduce works on nothing";
+    is ([⊎] $s), ($s.Bag), "Bag sum reduce works on one set";
+    is ([⊎] $s, $b), %(blood => 3, rhetoric => 1, love => 3).Bag, "Bag sum reduce works on two sets";
+    is ([⊎] $s, $b, $kb), %(blood => 4, rhetoric => 1, love => 5).Bag, "Bag sum reduce works on three sets";
 
-    is showkv([(+)] @d), showkv(∅), "Bag sum reduce works on nothing";
-    is showkv([(+)] $s), showkv($s.Bag), "Bag sum reduce works on one set";
-    is showkv([(+)] $s, $b), showkv({ blood => 3, rhetoric => 1, love => 3 }), "Bag sum reduce works on two sets";
-    is showkv([(+)] $s, $b, $kb), showkv({ blood => 4, rhetoric => 1, love => 5 }), "Bag sum reduce works on three sets";
+    is ([(+)] @d), (∅), "Bag sum reduce works on nothing";
+    is ([(+)] $s), ($s.Bag), "Bag sum reduce works on one set";
+    is ([(+)] set(), $s), ($s.Bag), "Bag sum reduce works on an empty set and a set";
+    is ([(+)] bag(), $s), ($s.Bag), "Bag sum reduce works on an empty bag and a set";
+    is ([(+)] $s, $b), %(blood => 3, rhetoric => 1, love => 3).Bag, "Bag sum reduce works on a set and a bag";
+    is ([(+)] $s, $b, $kb), %(blood => 4, rhetoric => 1, love => 5).Bag, "Bag sum reduce works on a set, a bag, and a baghash";
 
-    is showkv([⊍] @d), showkv(∅), "Bag multiply reduce works on nothing";
-    is showkv([⊍] $s), showkv($s.Bag), "Bag multiply reduce works on one set";
-    is showkv([⊍] $s, $b), showkv({ blood => 2, love => 2 }), "Bag multiply reduce works on two sets";
-    is showkv([⊍] $s, $b, $kb), showkv({ blood => 2, love => 4 }), "Bag multiply reduce works on three sets";
+    is ([⊍] @d), (∅), "Bag multiply reduce works on nothing";
+    is ([⊍] $s), ($s.Bag), "Bag multiply reduce works on one set";
+    is ([⊍] $s, $b), %(blood => 2, love => 2).Bag, "Bag multiply reduce works on two sets";
+    is ([⊍] $s, $b, $kb), %(blood => 2, love => 4).Bag, "Bag multiply reduce works on three sets";
 
-    is showkv([(.)] @d), showkv(∅), "Bag multiply reduce works on nothing";
-    is showkv([(.)] $s), showkv($s.Bag), "Bag multiply reduce works on one set";
-    is showkv([(.)] $s, $b), showkv({ blood => 2, love => 2 }), "Bag multiply reduce works on two sets";
-    is showkv([(.)] $s, $b, $kb), showkv({ blood => 2, love => 4 }), "Bag multiply reduce works on three sets";
+    is ([(.)] @d), (∅), "Bag multiply reduce works on nothing";
+    is ([(.)] $s), ($s.Bag), "Bag multiply reduce works on one set";
+    is ([(.)] $s, $b), %(blood => 2, love => 2).Bag, "Bag multiply reduce works on two sets";
+    is ([(.)] $s, $b, $kb), %(blood => 2, love => 4).Bag, "Bag multiply reduce works on three sets";
 
-    is showkv([(^)] @d), showkv(∅), "Bag symmetric difference reduce works on nothing";
+    is ([(^)] @d), ∅, "Bag symmetric difference reduce works on nothing";
     is ([(^)] $s), $s, "Set symmetric difference reduce works on one set";
     isa-ok ([(^)] $s), Set, "Set symmetric difference reduce works on one set, yields set";
     is ([(^)] $b), $b, "Bag symmetric difference reduce works on one bag";
     isa-ok ([(^)] $b), Bag, "Bag symmetric difference reduce works on one bag, yields bag";
-    is ([(^)] $s, $b), (blood => 1, love => 1, rhetoric => 1).Bag, "Bag symmetric difference reduce works on a bag and a set";
+    is ([(^)] $s, $b), %(blood => 1, love => 1, rhetoric => 1).Bag, "Bag symmetric difference reduce works on a bag and a set";
     isa-ok ([(^)] $s, $b), Bag, "... and produces a Bag";
-    is ([(^)] $b, $s), ( blood => 1, love => 1, rhetoric => 1 ).Bag, "... and is actually symmetric";
+    is ([(^)] $b, $s), %(blood => 1, love => 1, rhetoric => 1).Bag, "... and is actually symmetric";
     isa-ok ([(^)] $b, $s), Bag, "... and still produces a Bag that way too";
-    is ([(^)] $s, $ks, $kb), ( blood => 1, love => 1, rhetoric => 1 ).Bag, "Bag symmetric difference reduce works on three bags";
+    is ([(^)] $s, $ks, $kb), %(blood => 1, love => 1, rhetoric => 1).Bag, "Bag symmetric difference reduce works on three bags";
     isa-ok ([(^)] $s, $ks, $kb), Bag, "Bag symmetric difference reduce works on three bags";
 }
 

--- a/S03-operators/bag.t
+++ b/S03-operators/bag.t
@@ -66,8 +66,6 @@ sub symmetric-difference($a, $b) {
     ($a (|) $b) (-) ($b (&) $a)
 }
 
-#?rakudo 8 todo "Rakudo update in progress, but not done yet RT #124529"
-
 is showkv($s (^) $b), showkv(symmetric-difference($s, $b)), "Bag symmetric difference with Set is correct";
 isa-ok ($s (^) $b), Bag, "... and it's actually a Bag";
 is showkv($b (^) $s), showkv(symmetric-difference($s, $b)), "Set symmetric difference with Bag is correct";
@@ -194,23 +192,17 @@ ok bag(my @large_arr = ("a"...*)[^50000]), "... a large array goes into a bar - 
     is showkv([(.)] $s, $b), showkv({ blood => 2, love => 2 }), "Bag multiply reduce works on two sets";
     is showkv([(.)] $s, $b, $kb), showkv({ blood => 2, love => 4 }), "Bag multiply reduce works on three sets";
 
-    is showkv([(^)] @d), showset(∅), "Bag symmetric difference reduce works on nothing";
-    #?rakudo todo "NYI"
-    is showkv([(^)] $s), showset($s), "Set symmetric difference reduce works on one set";
-    #?rakudo todo "NYI"
-    isa-ok showkv([(^)] $s), Set, "Set symmetric difference reduce works on one set, yields set";
-    #?rakudo todo "NYI"
-    is showkv([(^)] $b), showkv($b), "Bag symmetric difference reduce works on one bag";
-    #?rakudo todo "NYI"
-    isa-ok showkv([(^)] $b), Bag, "Bag symmetric difference reduce works on one bag, yields bag";
-    #?rakudo 4 todo "Wrong answer at the moment"
-    is showkv([(^)] $s, $b), showkv({ blood => 1, love => 1, rhetoric => 1 }), "Bag symmetric difference reduce works on a bag and a set";
-    isa-ok showkv([(^)] $s, $b), Bag, "... and produces a Bag";
-    is showkv([(^)] $b, $s), showkv({ blood => 1, love => 1, rhetoric => 1 }), "... and is actually symmetric";
-    isa-ok showkv([(^)] $b, $s), Bag, "... and still produces a Bag that way too";
-    #?rakudo 2 todo "Crashing"
-    is showkv([(^)] $s, $b, $kb), showkv({ blood => 1, love => 1, rhetoric => 1 }), "Bag symmetric difference reduce works on three bags";
-    isa-ok showkv([(^)] $s, $b, $kb), Bag, "Bag symmetric difference reduce works on three bags";
+    is showkv([(^)] @d), showkv(∅), "Bag symmetric difference reduce works on nothing";
+    is ([(^)] $s), $s, "Set symmetric difference reduce works on one set";
+    isa-ok ([(^)] $s), Set, "Set symmetric difference reduce works on one set, yields set";
+    is ([(^)] $b), $b, "Bag symmetric difference reduce works on one bag";
+    isa-ok ([(^)] $b), Bag, "Bag symmetric difference reduce works on one bag, yields bag";
+    is ([(^)] $s, $b), (blood => 1, love => 1, rhetoric => 1).Bag, "Bag symmetric difference reduce works on a bag and a set";
+    isa-ok ([(^)] $s, $b), Bag, "... and produces a Bag";
+    is ([(^)] $b, $s), ( blood => 1, love => 1, rhetoric => 1 ).Bag, "... and is actually symmetric";
+    isa-ok ([(^)] $b, $s), Bag, "... and still produces a Bag that way too";
+    is ([(^)] $s, $ks, $kb), ( blood => 1, love => 1, rhetoric => 1 ).Bag, "Bag symmetric difference reduce works on three bags";
+    isa-ok ([(^)] $s, $ks, $kb), Bag, "Bag symmetric difference reduce works on three bags";
 }
 
 # vim: ft=perl6

--- a/S03-operators/mix.t
+++ b/S03-operators/mix.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 128;
+plan 135;
 
 sub showset($b) { $b.keys.sort.join(' ') }
 
@@ -66,18 +66,16 @@ sub symmetric-difference($a, $m) {
     ($a (|) $m) (-) ($m (&) $a)
 }
 
-#?rakudo 8 todo "Rakudo update in progress, but not done yet RT #124541"
-
-is showkv($b (^) $m), showkv(symmetric-difference($b, $m)), "Mix symmetric difference with Bag is correct";
+is ($b (^) $m), symmetric-difference($b, $m), "Mix symmetric difference with Bag is correct";
 isa-ok ($b (^) $m), Mix, "... and it's actually a Mix";
-is showkv($m (^) $b), showkv(symmetric-difference($b, $m)), "Bag symmetric difference with Mix is correct";
+is ($m (^) $b), symmetric-difference($b, $m), "Bag symmetric difference with Mix is correct";
 isa-ok ($m (^) $b), Mix, "... and it's actually a Mix";
 
 #?niecza todo "Test is wrong, implementation is wrong"
-is showkv($b (^) $mh), showkv(symmetric-difference($b, $mh)), "MixHash symmetric difference with Bag is correct";
+is ($b (^) $mh), symmetric-difference($b, $mh), "MixHash symmetric difference with Bag is correct";
 isa-ok ($b (^) $mh), Mix, "... and it's actually a Mix";
 #?niecza todo "Test is wrong, implementation is wrong"
-is showkv($mh (^) $b), showkv(symmetric-difference($b, $mh)), "Bag symmetric difference with MixHash is correct";
+is ($mh (^) $b), symmetric-difference($b, $mh), "Bag symmetric difference with MixHash is correct";
 isa-ok ($mh (^) $b), Mix, "... and it's actually a Mix";
 
 # Mix multiplication
@@ -190,46 +188,48 @@ ok mix(my @large_arr = ("a"...*)[^50000]), "... a large array goes into a bar - 
 }
 
 {
-    # my $b = set <blood love>;
-    # my $bh = BagHash.new(<blood rhetoric>);
-    # my $m = mix <blood blood rhetoric love love>;
-    # my $mh = MixHash.new(<blood love love>);
     my @d;
-    
-    is showkv([⊎] @d), showkv(∅), "Mix sum reduce works on nothing";
-    is showkv([⊎] $b), showkv($b.Mix), "Mix sum reduce works on one set";
-    is showkv([⊎] $b, $m), showkv({ blood => 2.1, love => 2.2, rhetoric => 1 }), "Mix sum reduce works on two sets";
-    is showkv([⊎] $b, $m, $mh), showkv({ blood => 3.2, love => 3.5, rhetoric => 1 }), "Mix sum reduce works on three sets";
+    # XXX: without this initialization, the test harness breaks on 196
+    my $tm = %(blood => 2.1, love => 2.2, rhetoric => 1).Mix;
 
-    is showkv([(+)] @d), showkv(∅), "Mix sum reduce works on nothing (Texas)";
-    is showkv([(+)] $m), showkv($m), "Mix sum reduce works on one set (Texas)";
-    is showkv([(+)] $b, $m), showkv({ blood => 2.1, love => 2.2, rhetoric => 1 }), "Mix sum reduce works on two sets (Texas)";
-    is showkv([(+)] $b, $m, $mh), showkv({ blood => 3.2, love => 3.5, rhetoric => 1 }), "Mix sum reduce works on three sets (Texas)";
+    is ([⊎] @d), ∅, "Mix sum reduce works on nothing";
+    is ([⊎] $b), $b.Mix, "Mix sum reduce works on one bag";
+    is ([⊎] $b, $m), %(blood => 2.1, love => 2.2, rhetoric => 1).Mix, "Mix sum reduce works on a bag and a mix";
+    is ([⊎] $b, $m, $mh), %(blood => 3.2, love => 3.5, rhetoric => 1).Mix, "Mix sum reduce works on a bag, a mix, and a mixhash";
+    is ([⊎] $mh, $m, $b), %(blood => 3.2, love => 3.5, rhetoric => 1).Mix, "Mix sum reduce works on a bag, a mix, and a mixhash and order doesn't matter";
 
-    is showkv([⊍] @d), showkv(∅), "Mix multiply reduce works on nothing";
-    is showkv([⊍] $b), showkv($b.Mix), "Mix multiply reduce works on one set";
-    is showkv([⊍] $b, $m), showkv({ blood => 1.1, love => 1.2 }), "Mix multiply reduce works on two sets";
-    is showkv([⊍] $b, $m, $mh), showkv({ blood => 1.21, love => 1.56 }), "Mix multiply reduce works on three sets";
+    is ([(+)] @d), ∅, "Mix sum reduce works on nothing (Texas)";
+    is ([(+)] $m), $m, "Mix sum reduce works on one set (Texas)";
+    is ([(+)] bag(), $m), $m, "Mix sum reduce with an empty bag should be the value of the mix (Texas)";
+    is ([(+)] $m, bag()), $m, "Mix sum reduce with an empty bag should be the value of the mix and is symmetric (Texas)";
+    is ([(+)] $b, $m), %(blood => 2.1, love => 2.2, rhetoric => 1).Mix, "Mix sum reduce works on bag and mix sets (Texas)";
+    is ([(+)] $m, $b), %(blood => 2.1, love => 2.2, rhetoric => 1).Mix, "Mix sum reduce works on bag and mix and is symmetric (Texas)";
+    is ([(+)] $b, $m, $mh), %(blood => 3.2, love => 3.5, rhetoric => 1).Mix, "Mix sum reduce works on a bag, a mix, and a mixhash (Texas)";
+    is ([(+)] $mh, $m, $b), %(blood => 3.2, love => 3.5, rhetoric => 1).Mix, "Mix sum reduce works on a bag, a mix, and a mixhash and order doesn't matter (Texas)";
 
-    is showkv([(.)] @d), showkv(∅), "Mix multiply reduce works on nothing (Texas)";
-    is showkv([(.)] $b), showkv($b.Mix), "Mix multiply reduce works on one set (Texas)";
-    is showkv([(.)] $b, $m), showkv({ blood => 1.1, love => 1.2 }), "Mix multiply reduce works on two sets (Texas)";
-    is showkv([(.)] $b, $m, $mh), showkv({ blood => 1.21, love => 1.56 }), "Mix multiply reduce works on three sets (Texas)";
+    is ([⊍] @d), ∅, "Mix multiply reduce works on nothing";
+    is ([⊍] $b), $b.Mix, "Mix multiply reduce works on one set";
+    is ([⊍] $b, $m), %( blood => 1.1, love => 1.2 ).Mix, "Mix multiply reduce works on two sets";
+    is ([⊍] $m, $b), %( blood => 1.1, love => 1.2 ).Mix, "Mix multiply reduce works on a bag and a mix and is symmetric";
+    is ([⊍] $b, $m, $mh), %( blood => 1.21, love => 1.56 ).Mix, "Mix multiply reduce works on a bag, a mix, and a mixhash";
+    is ([⊍] $m, $b, $mh), %( blood => 1.21, love => 1.56 ).Mix, "Mix multiply reduce works on a bag, a mix, and a mixhash and order doesn't matter";
 
-    is showkv([(^)] @d), showset(∅), "Mix symmetric difference reduce works on nothing";
-    #?rakudo 4 todo "NYI"
-    is showkv([(^)] $b), showset($b), "Bag symmetric difference reduce works on one set";
-    isa-ok showkv([(^)] $b), Bag, "Bag symmetric difference reduce works on one set, yields set";
-    is showkv([(^)] $m), showkv($m), "Mix symmetric difference reduce works on one mix";
-    isa-ok showkv([(^)] $m), Mix, "Mix symmetric difference reduce works on one mix, yields mix";
-    #?rakudo 4 todo "Wrong answer at the moment"
-    is showkv([(^)] $b, $m), showkv({ blood => 1, love => 1, rhetoric => 1 }), "Mix symmetric difference reduce works on a mix and a set";
-    isa-ok showkv([(^)] $b, $m), Mix, "... and produces a Mix";
-    is showkv([(^)] $m, $b), showkv({ blood => 1, love => 1, rhetoric => 1 }), "... and is actually symmetric";
-    isa-ok showkv([(^)] $m, $b), Mix, "... and still produces a Mix that way too";
-    #?rakudo 2 todo "Crashing"
-    is showkv([(^)] $b, $m, $mh), showkv({ blood => 1, love => 1, rhetoric => 1 }), "Mix symmetric difference reduce works on three mixs";
-    isa-ok showkv([(^)] $b, $m, $mh), Mix, "Mix symmetric difference reduce works on three mixs";
+    is ([(.)] @d), ∅, "Mix multiply reduce works on nothing (Texas)";
+    is ([(.)] $b), $b.Mix, "Mix multiply reduce works on one set (Texas)";
+    is ([(.)] $b, $m), %( blood => 1.1, love => 1.2 ).Mix, "Mix multiply reduce works on a bag and a mix (Texas)";
+    is ([(.)] $m, $b), %( blood => 1.1, love => 1.2 ).Mix, "Mix multiply reduce works on a bag and a mix and is symmetric (Texas)";
+    is ([(.)] $b, $m, $mh), %( blood => 1.21, love => 1.56 ).Mix, "Mix multiply reduce works on a bag, a mix, and a mixhash (Texas)";
+    is ([(.)] $m, $b, $mh), %( blood => 1.21, love => 1.56 ).Mix, "Mix multiply reduce works on a bag, a mix, and a mixhash and order doesn't matter (Texas)";
+
+    is ([(^)] @d), ∅, "Mix symmetric difference reduce works on nothing";
+    is ([(^)] $m), $m, "Mix symmetric difference reduce works on one mix";
+    isa-ok ([(^)] $m), Mix, "Mix symmetric difference reduce works on one mix, yields mix";
+    is ([(^)] $b, $m), %(blood => 0.1, love => 0.2, :rhetoric).Mix, "Mix symmetric difference reduce works on a mix and a bag";
+    isa-ok ([(^)] $b, $m), Mix, "... and produces a Mix";
+    is ([(^)] $m, $b), %(blood => 0.1, love => 0.2, :rhetoric).Mix, "... and is actually symmetric";
+    isa-ok ([(^)] $m, $b), Mix, "... and still produces a Mix that way too";
+    is ([(^)] $b, $m, $mh), (blood => 1, love => 1.1, :rhetoric).Mix, "Mix symmetric difference reduce works on three mixes";
+    isa-ok ([(^)] $b, $m, $mh), Mix, "Mix symmetric difference reduce works on three mixes produces a Mix";
 }
 
 # vim: ft=perl6


### PR DESCRIPTION
This time, we don't change any of the set tests.

All of the 'showkv' calls were removed as they are no longer necessary
and several new tests to ensure symmetric behavior on (+) and (.) operators.