### PR TITLE
Test for #125247

### DIFF
--- a/integration/error-reporting.t
+++ b/integration/error-reporting.t
@@ -2,7 +2,7 @@ use v6;
 use lib 't/spec/packages';
 
 use Test;
-plan 29;
+plan 30;
 
 use Test::Util;
 
@@ -214,7 +214,7 @@ is_run '...', {:out(''), :err{ not $^o.contains: 'Unhandled exception' }},
 # RT #125247
 is_run Q[#`{{ my long
 	      unfinished comment'],
-	      { :out(''), :err{ $^o.contains: 'was at line 1' }}, 'Unfinished comment error points on correct line';
+	      { :out(''), :err{ $^o.contains: 'line 1' }}, 'Unfinished comment error points on correct line';
 
 # RT #129800
 subtest 'X::Multi::NoMatch correct shows named arguments' => {

--- a/integration/error-reporting.t
+++ b/integration/error-reporting.t
@@ -211,6 +211,11 @@ throws-like ‘%::{''}’, X::Undeclared, line => /^\d+$/,
 is_run '...', {:out(''), :err{ not $^o.contains: 'Unhandled exception' }},
     'stub code must not produce `Unhandled exception` message';
 
+# RT #125247
+is_run Q[#`{{ my long
+	      unfinished comment'],
+	      { :out(''), :err{ $^o.contains: 'was at line 1' }}, 'Unfinished comment error points on correct line';
+
 # RT #129800
 subtest 'X::Multi::NoMatch correct shows named arguments' => {
     my class RT129800 { multi method foo ($) {} }


### PR DESCRIPTION
https://rt.perl.org/Public/Bug/Display.html?id=125247#ticket-history

The original ticket is about a proper error message for an unfinished multi-line comment. The error message should contain right line number, i.e. where the comment started.