### PR TITLE
A test for #130211

### DIFF
--- a/integration/error-reporting.t
+++ b/integration/error-reporting.t
@@ -217,9 +217,10 @@ is_run Q[#`{{ my long
 	      { :out(''), :err{ $^o.contains: 'line 1' }}, 'Unfinished comment error points on correct line';
 
 # RT 130211
-throws-like 'role R { method overload-this(){...} };
-             role C { method overload-this(){...} };
-             class A does R does C {};', X::Comp::AdHoc, message => /C .+? R/, 'all roles with unimplemented method pointed out in reverse order';
+throws-like 'role R-RT130211 { method overload-this(){...} };
+             role C-RT130211 { method overload-this(){...} };
+             class A does R does C {};', X::Comp::AdHoc, :message { .contains('R-RT130211') and
+                                                                    .contains('C-RT130211') }
 
 # RT #129800
 subtest 'X::Multi::NoMatch correct shows named arguments' => {

--- a/integration/error-reporting.t
+++ b/integration/error-reporting.t
@@ -220,7 +220,8 @@ is_run Q[#`{{ my long
 throws-like 'role R-RT130211 { method overload-this(){...} };
              role C-RT130211 { method overload-this(){...} };
              class A does R does C {};', X::Comp::AdHoc, :message { .contains('R-RT130211') and
-                                                                    .contains('C-RT130211') }
+                                                                    .contains('C-RT130211') }, 'all roles with unimplemented method pointed out in reverse order';
+
 
 # RT #129800
 subtest 'X::Multi::NoMatch correct shows named arguments' => {

--- a/integration/error-reporting.t
+++ b/integration/error-reporting.t
@@ -219,8 +219,8 @@ is_run Q[#`{{ my long
 # RT 130211
 throws-like 'role R-RT130211 { method overload-this(){...} };
              role C-RT130211 { method overload-this(){...} };
-             class A does R does C {};', X::Comp::AdHoc, :message { .contains('R-RT130211') and
-                                                                    .contains('C-RT130211') }, 'all roles with unimplemented method pointed out in reverse order';
+             class A does R does C {};', X::Comp::AdHoc, :message{ .contains('R-RT130211') and
+                                                                   .contains('C-RT130211') }, 'all roles with unimplemented method pointed out in reverse order';
 
 
 # RT #129800

--- a/integration/error-reporting.t
+++ b/integration/error-reporting.t
@@ -2,7 +2,7 @@ use v6;
 use lib 't/spec/packages';
 
 use Test;
-plan 30;
+plan 31;
 
 use Test::Util;
 
@@ -215,6 +215,11 @@ is_run '...', {:out(''), :err{ not $^o.contains: 'Unhandled exception' }},
 is_run Q[#`{{ my long
 	      unfinished comment'],
 	      { :out(''), :err{ $^o.contains: 'line 1' }}, 'Unfinished comment error points on correct line';
+
+# RT 130211
+throws-like 'role R { method overload-this(){...} };
+             role C { method overload-this(){...} };
+             class A does R does C {};', X::Comp::AdHoc, message => /C .+? R/, 'all roles with unimplemented method pointed out in reverse order';
 
 # RT #129800
 subtest 'X::Multi::NoMatch correct shows named arguments' => {


### PR DESCRIPTION
Related to https://github.com/rakudo/rakudo/pull/957. Closes https://rt.perl.org/Public/Bug/Display.html?id=130211.

I just wrote checking of reverse-ordered role names to be independent from exact message.