### PR TITLE
fix test description typos in S12-methods/accessors.t

### DIFF
--- a/S12-methods/accessors.t
+++ b/S12-methods/accessors.t
@@ -37,8 +37,8 @@ class A {
 my $a = A.new(a => (1, 2, 3, 4), b => [3, 4, 5, 6]);
 is $a.test-list-a,   4, '@.a contextualizes as (flat) list (1)';
 is $a.test-scalar-a, 1, '$.a contextualizes as item (1)';
-is $a.test-list-b,   4, '@.a contextualizes as (flat) list (2)';
-is $a.test-scalar-b, 1, '$.a contextualizes as item (2)';
+is $a.test-list-b,   4, '@.b contextualizes as (flat) list (2)';
+is $a.test-scalar-b, 1, '$.b contextualizes as item (2)';
 is $a.test-hash-a,   2, '%.a contextualizes as hash';
 
 # RT #78678


### PR DESCRIPTION
Fix some typos in test descriptions.