### PR TITLE
Add command line test for UTF-8 decoding of @*ARGS

### DIFF
--- a/S19-command-line/arguments.t
+++ b/S19-command-line/arguments.t
@@ -4,7 +4,7 @@ use lib 't/spec/packages';
 
 use Test;
 
-plan 3;
+plan 4;
 
 use Test::Util;
 
@@ -46,4 +46,10 @@ use Test::Util;
         err => { .chars < 256 && m/$dir/ && m/directory/ },
     },
     'concise error message when called script is a directory' );
+}
+
+{
+    is run($*EXECUTABLE, '-e', ｢print '“Hello world”'｣, :out).out.slurp-rest,
+        '“Hello world”',
+        'UTF-8 in arguments is decoded correctly';
 }


### PR DESCRIPTION
Testcase for the bug mentioned in MoarVM/MoarVM#482.

I couldn't get the bug to reproduce with the is_run sub the rest of this file uses, so I borrowed the `is run($*EXECUTABLE, '-e'` pattern from another test file.