### PR TITLE
Tests for self-referential things

### DIFF
--- a/S02-types/WHICH.t
+++ b/S02-types/WHICH.t
@@ -350,7 +350,6 @@ my @exception = <
   X::Syntax::Variable::BadType
   X::Syntax::Variable::ConflictingTypes
   X::Syntax::Variable::IndirectDeclaration
-  X::Syntax::Variable::Initializer
   X::Syntax::Variable::Match
   X::Syntax::Variable::MissingInitializer
   X::Syntax::Variable::Numeric

--- a/S04-declarations/my.t
+++ b/S04-declarations/my.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 105;
+plan 108;
 
 #L<S04/The Relationship of Blocks and Declarations/"declarations, all
 # lexically scoped declarations are visible"> 
@@ -159,23 +159,20 @@ is(EVAL('loop (my $x = 1, my $y = 2; $x > 0; $x--) { last }; $y #OK'), 2, '2nd m
     is($f, 5, "two lexicals declared in scope is noop");
 }
 
-# RT #121807
-throws-like 'my %h is default(%h<foo>)',
-    X::Syntax::Variable::Initializer, name => '%h';
-
 # RT #125371
-throws-like 'my $z = $z', X::Syntax::Variable::Initializer, name => '$z';
+eval-lives-ok ‘my $a :=   $a; say $a’, ‘Self-referential assignment does not segfault’;
+eval-lives-ok ‘my $a := $::a; say $a’, ‘Self-referential assignment does not segfault’;
+
+# Other self-referential tests
+is EVAL(‘my @loop =  42, @loop;  @loop[1][1][1][0]’), 42, ‘Self-referential array’;
+is EVAL(‘my $loop = (42, $loop); $loop[1][1][1][0]’), 42, ‘Self-referential list’;
+ok EVAL(‘my %loop = 42 => %loop; %loop<42><42><42> === %loop’), ‘Self-referential hash’;
+ok EVAL(‘my $loop = 42 => $loop, $loop<42><42><42> === $loop’), ‘Self-referential pair’;
 
 # RT #125371
 {
     my $py = 0 && try { my $py = 42; $py.bla() };
     is $py, 0, 'initializing a variable using a try block containing same name works';
-}
-
-# RT #87034
-{
-    throws-like 'my @foo := 1..3, (@foo Z+ 100)',
-        X::Syntax::Variable::Initializer, name => '@foo';
 }
 
 # interaction of my and EVAL


### PR DESCRIPTION
Some tests were deleted according to the rakudo pull request that
removes the error completely. Let's take a look at the deleted tests
one by one.

The first test checks that ｢is default(%h<foo>)｣ gives “Cannot use
variable $!name in declaration to initialize itself” error. This error
is completely irrelevant to what actually happens. See comments
on RT #121807.

Second test makes sure that ｢my $z = $z｣ is a compile-time error. It
could be so, but I see no basis for this. This particular case *has
never been a problem*. All rakudo versions since 2014.01 (which is the
first release of rakudo on moar) result in $z being Any, just like if
you left $z uninitialized.

The last test is the only one that tests for misuse (using
self-referential things with binding). It is based on a 5 year old
ticket that expected some completely different behavior. This code
does not cause rakudo to blow up, but it is still something we should
complain about compile time. After the removal of this error, this
code will now fail during run time because @foo will end up being
Mu. Not too bad, but could be better.

Yet nothing for problematic cases that are caused by what the error is
talking about.

Instead, I've added some tests that check that self-referential
arrays (and other self-referential things) are working correctly.

It would be nice to have some sort of design decision on what should
happen with binding. For example, we can say that getting Mu there is
OK. See RT #87034 for further discussions.