### PR TITLE
Tests for constants with lexical scopes on the RHS

### DIFF
--- a/S04-declarations/constant.t
+++ b/S04-declarations/constant.t
@@ -2,7 +2,7 @@ use v6;
 
 use Test;
 use lib 't/spec/packages';
-plan 72;
+plan 75;
 
 # L<S04/The Relationship of Blocks and Declarations/"The new constant declarator">
 
@@ -382,6 +382,10 @@ throws-like q[constant Mouse = Rat; constant Mouse = Rat], X::Redeclaration,
     use ExportConstant;
     is &constant-sub(), 'win', 'Can call an exported constant sub';
     ok "foo" ~~ $constant-regex, 'Can match a exported constant regex';
+
+    is &constant-sub-with-call(), 'WIN', 'Can call an exported constant sub which make a call';
+    is-deeply @const-map, <FOO BAR BAZ>, 'Exported constant assigned to map {...}';
+    ok 'foo' ~~ $const-regex-block, 'Can match a exported constant regex with a block';
 }
 
 # vim: ft=perl6

--- a/packages/ExportConstant.pm6
+++ b/packages/ExportConstant.pm6
@@ -1,2 +1,5 @@
 constant $constant-regex is export =  /fo*/;
 constant &constant-sub   is export  = sub { "win" };
+constant &constant-sub-with-call is export = sub { uc "win" };
+constant @const-map      is export  = map { uc $_ }, <foo bar baz>;
+constant $const-regex-block  is export  = /{ uc "win"} ./;


### PR DESCRIPTION
Tests bug fixes introduced with this patch:
https://github.com/rakudo/rakudo/commit/dc4ed746ddeb562688985a41e9a51380d7bc0cf6
see RT #127858, #131705