### PR TITLE
Fix incorrect/skipped test for RT#124848 (RT#69192)

### DIFF
--- a/S12-methods/multi.t
+++ b/S12-methods/multi.t
@@ -63,7 +63,7 @@ is Bar.new.a("not an Int"), 'Any-method in Foo';
 }
 
 # RT #69192
-#?rakudo skip 'unknown bug RT #124848'
+# RT #124848'
 {
     role R5 {
         multi method rt69192()       { push @.order, 'empty' }
@@ -76,21 +76,21 @@ is Bar.new.a("not an Int"), 'Any-method in Foo';
 
     {
         my RT69192 $bot .= new();
-        ($bot does R5) does R6;
+        $bot does (R5, R6);
         $bot.*rt69192;
         is $bot.order, <empty>, 'multi method called once on empty signature';
     }
 
     {
         my RT69192 $bot .= new();
-        ($bot does R5) does R6;
+        $bot does (R5, R6);
         $bot.*rt69192('RT #69192');
         is $bot.order, <Str>, 'multi method called once on Str signature';
     }
 
     {
         my RT69192 $bot .= new();
-        ($bot does R5) does R6;
+        $bot does (R5, R6);
         $bot.*rt69192( 69192 );
         is $bot.order, <Numeric>, 'multi method called once on Numeric signature';
     }


### PR DESCRIPTION
  The results of this test are correct for a runtime
  mixin where roles were added one at a time... which
  is one of the reasons why "does (Role1, Role2, Role3)"
  exists.  So use it.  What probably happened in #124848
  was the wrong fix was applied to the test after
  "does" lost the associativity it was not supposed to have.