### PR TITLE
Use `v6.c` instead of `v6` so we get right language version when 6.d comes out

### DIFF
--- a/S02-lexical-conventions/comments.t
+++ b/S02-lexical-conventions/comments.t
@@ -183,7 +183,7 @@ plan 51;
 #?niecza todo
 {
     # RT #70752
-    lives-ok { EVAL "#=======\n#=======\nuse v6;" }, 
+    lives-ok { EVAL "#=======\n#=======\nuse v6.c;" }, 
       "pragma use after single line comments";
 }
 

--- a/S10-packages/precompilation.t
+++ b/S10-packages/precompilation.t
@@ -45,7 +45,7 @@ is $_, 'True' for @precompiled2;
 
 # RT #123272
 my @keys2 = Test::Util::run( q:to"--END--").lines;
-    use v6;
+    use v6.c;
     use lib 't/spec/packages';
     use Example2::T;
 

--- a/S11-modules/InnerModule.pm
+++ b/S11-modules/InnerModule.pm
@@ -1,5 +1,5 @@
 unit module InnerModule;
-use v6;
+use v6.c;
 
 sub foo is export(:DEFAULT) {'Inner::foo'}
 sub bar is export {'Inner::bar'}

--- a/S11-modules/OuterModule.pm
+++ b/S11-modules/OuterModule.pm
@@ -1,4 +1,4 @@
 unit module OuterModule;
-use v6;
+use v6.c;
 
 use InnerModule :ALL :EXPORT;

--- a/S17-supply/batch.t
+++ b/S17-supply/batch.t
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use lib 't/spec/packages';
 
 use Test;

--- a/S22-package-format/local.t
+++ b/S22-package-format/local.t
@@ -6,7 +6,7 @@ plan 19;
 # initializations
 my $cwd := $*CWD;
 my $nanoonanoo := '
-use v6;
+use v6.c;
 use Test;
 class NanooNanoo { }
 ';

--- a/S24-testing/test-data/line-number-cmp-ok.txt
+++ b/S24-testing/test-data/line-number-cmp-ok.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-dies-ok.txt
+++ b/S24-testing/test-data/line-number-dies-ok.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-eval-dies-ok.txt
+++ b/S24-testing/test-data/line-number-eval-dies-ok.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-eval-lives-ok.txt
+++ b/S24-testing/test-data/line-number-eval-lives-ok.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-is-deeply.txt
+++ b/S24-testing/test-data/line-number-is-deeply.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-is.txt
+++ b/S24-testing/test-data/line-number-is.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-is_approx.txt
+++ b/S24-testing/test-data/line-number-is_approx.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-isa-ok.txt
+++ b/S24-testing/test-data/line-number-isa-ok.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-isnt.txt
+++ b/S24-testing/test-data/line-number-isnt.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-lives-ok.txt
+++ b/S24-testing/test-data/line-number-lives-ok.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-nok.txt
+++ b/S24-testing/test-data/line-number-nok.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-ok.txt
+++ b/S24-testing/test-data/line-number-ok.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/line-number-throws-like.txt
+++ b/S24-testing/test-data/line-number-throws-like.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S24-testing/test-data/todo-passed.txt
+++ b/S24-testing/test-data/todo-passed.txt
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 
 plan 1;

--- a/S32-basics/warn.t
+++ b/S32-basics/warn.t
@@ -37,7 +37,7 @@ use Test::Util;
 }
 
 #?niecza todo
-is_run 'use v6; warn; say "alive"',
+is_run 'use v6.c; warn; say "alive"',
     {
         status => 0,
         out => rx/alive/,
@@ -46,7 +46,7 @@ is_run 'use v6; warn; say "alive"',
     'warn() without arguments';
 
 # RT #124767
-is_run 'use v6; warn("OH NOEZ"); say "alive"',
+is_run 'use v6.c; warn("OH NOEZ"); say "alive"',
     {
         status => 0,
         out => rx/alive/,
@@ -54,7 +54,7 @@ is_run 'use v6; warn("OH NOEZ"); say "alive"',
     },
     'warn() with arguments; line number';
 
-is_run 'use v6; try {warn("OH NOEZ") }; say "alive"',
+is_run 'use v6.c; try {warn("OH NOEZ") }; say "alive"',
     {
         status => 0,
         out => rx/alive/,
@@ -63,7 +63,7 @@ is_run 'use v6; try {warn("OH NOEZ") }; say "alive"',
     'try does not suppress warnings';
 
 #?niecza todo 'quietly NYI'
-is_run 'use v6; quietly {warn("OH NOEZ") }; say "alive"',
+is_run 'use v6.c; quietly {warn("OH NOEZ") }; say "alive"',
     {
         status => 0,
         out => rx/alive/,

--- a/S32-exceptions/misc.t
+++ b/S32-exceptions/misc.t
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 use lib "t/spec/packages";
 use Test::Util;

--- a/S32-io/IO-Socket-INET.pl
+++ b/S32-io/IO-Socket-INET.pl
@@ -5,7 +5,7 @@
 # can be removed after stability of tests has been confirmed
 # on multiple operating systems.
 
-use v6;
+use v6.c;
 
 constant PF_INET     = 2; # these should move into a file,
 constant SOCK_STREAM = 1; # but what name and directory?

--- a/S32-trig/TrigTestSupport
+++ b/S32-trig/TrigTestSupport
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 use Test;
 plan *;
 

--- a/integration/advent2012-day06.t
+++ b/integration/advent2012-day06.t
@@ -6,7 +6,7 @@ use Test::Util;
 plan 2;
 
 my $main = q:to"END-MAIN";
-    use v6;
+    use v6.c;
     use lib 'lib';
 
     # the main functionality of the script

--- a/integration/error-reporting.t
+++ b/integration/error-reporting.t
@@ -7,7 +7,7 @@ use lib 't/spec/packages';
 
 use Test::Util;
 
-is_run "use v6;\n'a' =~ /foo/", {
+is_run "use v6.c;\n'a' =~ /foo/", {
     status  => { $_ != 0 },
     out     => '',
     err     => rx/<<2>>/
@@ -19,7 +19,7 @@ is_run "my \$x = 2 * 3;\ndie \$x", {
     err     => all(rx/6/, rx/<<2>>/),
 }, 'Runtime error contains line number';
 
-is_run "use v6;\n\nsay 'Hello';\nsay 'a'.my_non_existent_method_6R5();",
+is_run "use v6.c;\n\nsay 'Hello';\nsay 'a'.my_non_existent_method_6R5();",
     {
         status  => { $_ != 0 },
         out     => /Hello\r?\n/,
@@ -27,7 +27,7 @@ is_run "use v6;\n\nsay 'Hello';\nsay 'a'.my_non_existent_method_6R5();",
     }, 'Method not found error mentions method name and line number';
 
 # RT #75446
-is_run 'use v6;
+is_run 'use v6.c;
 sub bar {
     pfff();
 }
@@ -61,7 +61,7 @@ is_run 'say 42; nosuchsub()',
 }
 
 # RT #76112
-is_run 'use v6;
+is_run 'use v6.c;
 class A { has $.x is rw };
 A.new.x(42);',
     {
@@ -112,7 +112,7 @@ is_run 'die "foo"; END { say "end run" }',
 
 # RT #113848
 {
-    try EVAL 'use v6;     # line 1
+    try EVAL 'use v6.c;     # line 1
              # another line so we three in total
              (1 + 2) = 3; # line 3
         ';


### PR DESCRIPTION
The commit looks safe to me to merge, but since this is 6.c-errata branch, I figured it could use a pair of extra eyes to look over it first.