### PR TITLE
Add tests for backtracking into alternations

### DIFF
--- a/S05-metasyntax/longest-alternative.t
+++ b/S05-metasyntax/longest-alternative.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 58;
+plan 62;
 
 #L<S05/Unchanged syntactic features/"While the syntax of | does not change">
 
@@ -474,6 +474,17 @@ is "abcde" ~~ / ab <![e]> cde | ab.. /, "abcde", 'negative lookahead does LTM pr
     }
     ok Oops.parse('ab'),
         'LTM with quantifier ** 1..2 followed by something else matches correctly';
+}
+
+
+# L<S05/Backtracking control>
+
+# RT #131973
+{
+    is 'ab' ~~ / [ab | a ] b /,       'ab', 'backtrack into |';
+    is 'ab' ~~ / [ab | a ]: b /,      Nil,  'don\'t backtrack into [ | ]:';
+    is 'ab' ~~ / :r [ab | a ] b /,    Nil,  'don\'t backtrack into | under :r';
+    is 'ab' ~~ / :r [ab | a ]:! b /,  'ab', 'backtrack into [ | ]:! despite :r';
 }
 
 # vim: ft=perl6 et

--- a/S05-metasyntax/sequential-alternation.t
+++ b/S05-metasyntax/sequential-alternation.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 10;
+plan 14;
 
 #L<S05/New metacharacters/"As with the disjunctions | and ||">
 
@@ -32,6 +32,17 @@ plan 10;
 
     ok $str ~~ m/ ||@list /;
     is ~$/,  'xx', 'first ||@list alternative matches';
+}
+
+
+# L<S05/Backtracking control>
+
+# RT #130117 and #131973
+{
+    is 'ab' ~~ / [ab || a ] b /,       'ab', 'backtrack into ||';
+    is 'ab' ~~ / [ab || a ]: b /,      Nil,  'don\'t backtrack into [ || ]:';
+    is 'ab' ~~ / :r [ab || a ] b /,    Nil,  'don\'t backtrack into || under :r';
+    is 'ab' ~~ / :r [ab || a ]:! b /,  'ab', 'backtrack into [ || ]:! despite :r';
 }
 
 # vim: ft=perl6


### PR DESCRIPTION
They're the bottom eight tests I listed in the description of the already merged NQP PR https://github.com/perl6/nqp/pull/368.
(The other ones listed there, for quantifiers, seem to be already covered in `S05-mass/rx.t`.)

This closes [RT #130117](https://rt.perl.org/Ticket/Display.html?id=130117) and  [RT #131973](https://rt.perl.org/Ticket/Display.html?id=131973).