### PR TITLE
Allow tests to be run outside of rakudo dir

### DIFF
--- a/MISC/bug-coverage-stress.t
+++ b/MISC/bug-coverage-stress.t
@@ -1,5 +1,5 @@
 use v6.c;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S01-perl-5-integration/eval_lex.t
+++ b/S01-perl-5-integration/eval_lex.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 2;

--- a/S02-literals/allomorphic.t
+++ b/S02-literals/allomorphic.t
@@ -1,7 +1,7 @@
 # S02-literals/allomorphic.t --- Tests for the various allmorphic types, and val() processing
 
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S02-literals/heredocs.t
+++ b/S02-literals/heredocs.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 34;

--- a/S02-literals/pairs.t
+++ b/S02-literals/pairs.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Idempotence;

--- a/S02-literals/quoting.t
+++ b/S02-literals/quoting.t
@@ -1,6 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
-use lib <packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 191;

--- a/S02-literals/string-interpolation.t
+++ b/S02-literals/string-interpolation.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S02-magicals/78258.t
+++ b/S02-magicals/78258.t
@@ -1,5 +1,5 @@
 use v6;
 
-use lib 't/spec/S02-magicals';
-use UsedEnv; # contains plan
+use lib $?FILE.IO.parent;
 
+use UsedEnv; # contains plan

--- a/S02-magicals/KERNEL.t
+++ b/S02-magicals/KERNEL.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S02-magicals/args.t
+++ b/S02-magicals/args.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S02-magicals/env.t
+++ b/S02-magicals/env.t
@@ -1,7 +1,7 @@
 use v6;
 
 # Tests for magic variables
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S02-magicals/pid.t
+++ b/S02-magicals/pid.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S02-magicals/progname.t
+++ b/S02-magicals/progname.t
@@ -1,13 +1,13 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;
 
 plan 4;
 
-ok($*PROGRAM ~~ / t['/'|'\\']spec['/'|'\\']S02'-'magicals['/'|'\\']progname'.'\w+$/, "progname var matches test file path");
-ok(PROCESS::<$PROGRAM> ~~ / t['/'|'\\']spec['/'|'\\']S02'-'magicals['/'|'\\']progname'.'\w+$/, "progname var accessible as context var");
+ok($*PROGRAM ~~ /S02'-'magicals['/'|'\\']progname'.'\w+$/, "progname var matches test file path");
+ok(PROCESS::<$PROGRAM> ~~ /S02'-'magicals['/'|'\\']progname'.'\w+$/, "progname var accessible as context var");
 
 # NOTE:
 # above is a junction hack for Unix and Win32 file

--- a/S02-one-pass-parsing/misc.t
+++ b/S02-one-pass-parsing/misc.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S02-types/bag-iterator.t
+++ b/S02-types/bag-iterator.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Iterator;
 
 plan 2 * 7;

--- a/S02-types/capture.t
+++ b/S02-types/capture.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 43;

--- a/S02-types/declare.t
+++ b/S02-types/declare.t
@@ -390,7 +390,7 @@ plan 70;
 # L<S09/Sized types/>
 # int in1 int2 int4 int8 int16 in32 int64
 # uint uin1 uint2 uint4 uint8 uint16 uint32 uint64
-# t/spec/S02-builtin_data_types/int-uint.t already has these covered
+# S02-builtin_data_types/int-uint.t already has these covered
 
 # L<S09/Sized types/"num16">
 # num16 num32 num64 num128

--- a/S02-types/list.t
+++ b/S02-types/list.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S02-types/mix-iterator.t
+++ b/S02-types/mix-iterator.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Iterator;
 
 plan 2 * 7;

--- a/S02-types/mix.t
+++ b/S02-types/mix.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Util;
 use Test;
 

--- a/S02-types/mixhash.t
+++ b/S02-types/mixhash.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Util;
 use Test;
 

--- a/S02-types/mu.t
+++ b/S02-types/mu.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S02-types/range-iterator.t
+++ b/S02-types/range-iterator.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Iterator;
 
 plan 12 * 6;

--- a/S02-types/set-iterator.t
+++ b/S02-types/set-iterator.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Iterator;
 
 plan 2 * 6;

--- a/S02-types/version.t
+++ b/S02-types/version.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S02-types/whatever.t
+++ b/S02-types/whatever.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S03-metaops/hyper.t
+++ b/S03-metaops/hyper.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib "t/spec/packages";
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S03-operators/context-forcers.t
+++ b/S03-operators/context-forcers.t
@@ -172,7 +172,7 @@ sub eval_elsewhere($code){ EVAL($code) }
 }
 
 # int context
-# tested in t/spec/S32-num/int.t
+# tested in S32-num/int.t
 
 {
     my $x = [0, 100, 280, 33, 400, 5665];

--- a/S03-operators/minmax.t
+++ b/S03-operators/minmax.t
@@ -11,7 +11,7 @@ plan 39;
 
 =begin description
 
-This test min/max functions in their operator form. To see them tested in their other forms, see C<t/spec/S32-list/minmax.t>
+This test min/max functions in their operator form. To see them tested in their other forms, see C<S32-list/minmax.t>
 
 =end description
 

--- a/S03-operators/range.t
+++ b/S03-operators/range.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S03-operators/repeat.t
+++ b/S03-operators/repeat.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib ('t/spec/packages'.IO.e ?? 't/spec/packages' !! 'packages');
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Util;
 
 =begin description

--- a/S03-smartmatch/disorganized.t
+++ b/S03-smartmatch/disorganized.t
@@ -25,11 +25,11 @@ sub eval_elsewhere($code){ EVAL($code) }
 # Set   Hash
 # Any   Hash
 
-# Regex tests are in spec/S05-*
+# Regex tests are in S05-*
 
 #L<S03/"Smart matching"/in range>
 {
-    # more range tests in t/spec/S03-operators/range.t
+    # more range tests in S03-operators/range.t
     is-deeply((5 ~~ 1 .. 10), True, "5 is in 1 .. 10");
     is-deeply(!(10 ~~ 1 .. 5), True, "10 is not in 1 .. 5");
     is-deeply(!(1 ~~ 5 .. 10), True, "1 is not i n 5 .. 10");

--- a/S04-declarations/constant.t
+++ b/S04-declarations/constant.t
@@ -1,7 +1,7 @@
 use v6;
 
 use Test;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 plan 72;
 
 # L<S04/The Relationship of Blocks and Declarations/"The new constant declarator">

--- a/S04-exception-handlers/control.t
+++ b/S04-exception-handlers/control.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S04-exceptions/exceptions-json.t
+++ b/S04-exceptions/exceptions-json.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S04-exceptions/fail.t
+++ b/S04-exceptions/fail.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S04-phasers/end.t
+++ b/S04-phasers/end.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S04-phasers/enter-leave.t
+++ b/S04-phasers/enter-leave.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S04-phasers/in-loop.t
+++ b/S04-phasers/in-loop.t
@@ -7,8 +7,8 @@ plan 11;
 # TODO, based on synopsis 4:
 #
 # * KEEP, UNDO, PRE, POST, CONTROL
-#   CATCH is tested in t/spec/S04-statements/try.t
-#                  and t/spec/S04-exception-handlers/catch.t
+#   CATCH is tested in S04-statements/try.t
+#                  and S04-exception-handlers/catch.t
 #
 # * $var will undo, etc
 #

--- a/S04-phasers/keep-undo.t
+++ b/S04-phasers/keep-undo.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S04-statements/loop.t
+++ b/S04-statements/loop.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S04-statements/quietly.t
+++ b/S04-statements/quietly.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S04-statements/return.t
+++ b/S04-statements/return.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S05-grammar/example.t
+++ b/S05-grammar/example.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S05-interpolation/regex-in-variable.t
+++ b/S05-interpolation/regex-in-variable.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S05-match/blocks.t
+++ b/S05-match/blocks.t
@@ -81,7 +81,7 @@ my $discarded = do {
 }
 
 # TODO: repeat ... until, gather/take, lambdas, if/unless statement modifiers
-# TODO: move to t/spec/integration/
+# TODO: move to integration/
 
 # test that a regex in an `if' matches against $_, not boolifies
 

--- a/S05-match/capturing-contexts.t
+++ b/S05-match/capturing-contexts.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use MONKEY-TYPING;
 

--- a/S05-metasyntax/regex.t
+++ b/S05-metasyntax/regex.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S05-modifier/ratchet.t
+++ b/S05-modifier/ratchet.t
@@ -4,7 +4,7 @@ plan 5;
 
 #L<S05/Modifiers/"The new :r or :ratchet modifier">
 # for other tests see
-# t/spec/S05-mass/rx.t
+# S05-mass/rx.t
 
 # backtracking
 regex aplus { a+ };

--- a/S05-substitution/subst.t
+++ b/S05-substitution/subst.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S05-transliteration/trans.t
+++ b/S05-transliteration/trans.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S06-currying/assuming-and-mmd.t
+++ b/S06-currying/assuming-and-mmd.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Assuming;

--- a/S06-currying/misc.t
+++ b/S06-currying/misc.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Assuming;

--- a/S06-currying/named.t
+++ b/S06-currying/named.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Assuming;

--- a/S06-currying/positional.t
+++ b/S06-currying/positional.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Assuming;

--- a/S06-currying/slurpy.t
+++ b/S06-currying/slurpy.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Assuming;

--- a/S06-operator-overloading/imported-subs.t
+++ b/S06-operator-overloading/imported-subs.t
@@ -1,13 +1,13 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 
 plan 20;
 
 {
-    # defined in t/spec/packages/Exportops.pm
+    # defined in packages/Exportops.pm
     use Exportops;
 
     ok EVAL('5!'), 'postfix:<!> was exported...';

--- a/S06-operator-overloading/methods.t
+++ b/S06-operator-overloading/methods.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S06-other/main-usage.t
+++ b/S06-other/main-usage.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 plan 31;

--- a/S06-other/main.t
+++ b/S06-other/main.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S06-signature/definite-return.t
+++ b/S06-signature/definite-return.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S06-signature/introspection.t
+++ b/S06-signature/introspection.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S06-signature/slurpy-params.t
+++ b/S06-signature/slurpy-params.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 
@@ -49,7 +49,7 @@ sub whatever {
 
 whatever( 'a', 'b', 'c', 'd' );
 
-# use to be t/spec/S06-signature/slurpy-params-2.t
+# use to be S06-signature/slurpy-params-2.t
 
 
 =begin pod

--- a/S06-signature/types.t
+++ b/S06-signature/types.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S10-packages/README
+++ b/S10-packages/README
@@ -1,4 +1,4 @@
-t/spec/S10-packages/README
+S10-packages/README
 
-The packages these tests use are stored in t/spec/packages to avoid the use of
+The packages these tests use are stored in packages to avoid the use of
 a hyphen in the package name, which is not allowed without quoting.

--- a/S10-packages/basic.t
+++ b/S10-packages/basic.t
@@ -2,7 +2,7 @@ use v6;
 
 # L<S10/Packages>
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 
@@ -147,7 +147,7 @@ eval-lives-ok q' module MapTester { (1, 2, 3).map: { $_ } } ',
               'map works in a module (RT #64606)';
 
 {
-    use lib 't/spec/packages';
+    use lib $?FILE.IO.parent(2).add("packages");
     use ArrayInit;
     my $first_call = array_init();
     is array_init(), $first_call,
@@ -241,7 +241,7 @@ throws-like q[
 
 # RT #121253
 {
-    use lib 't/spec/packages';
+    use lib $?FILE.IO.parent(2).add("packages");
     use Bar;
     use Baz;
     use Foo;
@@ -255,14 +255,14 @@ throws-like q[
 
 # RT #76606
 {
-    use lib 't/spec/packages';
+    use lib $?FILE.IO.parent(2).add("packages");
     lives-ok { use RT76606 },
         'autovivification works with nested "use" directives (import from two nested files)';
 }
 
 # RT #120561
 {
-    lives-ok { use lib "$?FILE.IO.dirname()/t/spec/packages" },
+    lives-ok { use lib "." },
         'no Null PMC access with "use lib $double_quoted_string"';
 }
 
@@ -325,11 +325,11 @@ throws-like q[
 # RT #131540
 subtest '`use lib` accepts IO::Path objects' => {
     plan 2;
-
-    is_run ｢use lib 't/spec/packages'.IO; use Test::Util｣,
+    constant $path = $?FILE.IO.parent(2).add('packages').absolute;
+    is_run "use lib '{$path}'.IO; use Test::Util",
         {:out(''), :err(''), :0status}, 'single object';
 
-    is_run ｢use lib ('.', '.'.IO, 't/spec/packages'.IO); use Test::Util｣,
+    is_run "use lib '$path', '{$path}'.IO; use Test::Util",
         {:out(''), :err(''), :0status}, 'a mixed list of IO::Path and Str';
 }
 

--- a/S10-packages/export.t
+++ b/S10-packages/export.t
@@ -1,32 +1,32 @@
 use v6;
 
 # L<S11/Exportation>
-use lib '.';
+use lib $?FILE.IO.parent.child("packages");
 
 use Test;
 
 plan 7;
 
 # (Automatic s:g/::/$PATH_SEPARATOR_OF_CUR_OS/)++
-use t::spec::packages::Export_PackB;
+use packages::Export_PackB;
 
-ok t::spec::packages::Export_PackB::does_export_work(),
+ok packages::Export_PackB::does_export_work(),
   "'is export' works correctly even when not exporting to Main (1)";
 
-# t::spec::packages::Export_PackA::exported_foo should not have been exported into
+# packages::Export_PackA::exported_foo should not have been exported into
 # our namespace.
-dies-ok { exported_foo() },
+dies-ok { ::('&exported_foo')() },
   "'is export' works correctly even when not exporting to Main (2)";
 
 {
-    use t::spec::packages::Export_PackC;
+    use packages::Export_PackC;
     lives-ok { foo_packc() }, "lexical export works";
 }
-dies-ok { foo_packc() }, "lexical export is indeed lexical";
+dies-ok { ::('&foo_packc')() }, "lexical export is indeed lexical";
 
 
 sub moose {
-    use t::spec::packages::Export_PackD;
+    use packages::Export_PackD;
     is(this_gets_exported_lexically(), 'moose!', "lexical import survives pad regeneration")
 }
 

--- a/S10-packages/joined-namespaces.t
+++ b/S10-packages/joined-namespaces.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S10-packages/nested-use.t
+++ b/S10-packages/nested-use.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 
@@ -19,30 +19,33 @@ lives-ok {
     require FooBar;
 }, '... we can require FooBar (which requires Bar (which requires Foo))';
 
-my $foobar = ::FooBar.new();
-
 {
-    my $val;
-    lives-ok {
-        $val = $foobar.foobar()
-    }, '... the FooBar::foobar method resolved';
-    is($val, 'foobar', '... the FooBar::foobar method resolved');
-}
+    require FooBar;
+    my $foobar = ::('FooBar').new();
 
-{
-    my $val;
-    lives-ok {
-        $val = $foobar.bar()
-    }, '... the Bar::bar method resolved';
-    is($val, 'bar', '... the Bar::bar method resolved');
-}
+    {
+        my $val;
+        lives-ok {
+            $val = $foobar.foobar()
+        }, '... the FooBar::foobar method resolved';
+        is($val, 'foobar', '... the FooBar::foobar method resolved');
+    }
 
-{
-    my $val;
-    lives-ok {
-        $val = $foobar.foo()
-    }, '... the Foo::foo method resolved';
-    is($val, 'foo', '... the Foo::foo method resolved');
+    {
+        my $val;
+        lives-ok {
+            $val = $foobar.bar()
+        }, '... the Bar::bar method resolved';
+        is($val, 'bar', '... the Bar::bar method resolved');
+    }
+
+    {
+        my $val;
+        lives-ok {
+            $val = $foobar.foo()
+        }, '... the Foo::foo method resolved';
+        is($val, 'foo', '... the Foo::foo method resolved');
+    }
 }
 
 # vim: ft=perl6

--- a/S10-packages/require-and-use--dead-file.t
+++ b/S10-packages/require-and-use--dead-file.t
@@ -1,16 +1,16 @@
 use v6;
 
 # L<S11/Runtime Importation>
-use lib '.';
+use lib $?FILE.IO.parent.child("packages");
 
 use Test;
 
 plan 18;
 
 my @tests = (
-  "t::spec::packages::RequireAndUse1", { $^a == 42 },
-  "t::spec::packages::RequireAndUse2", { $^a != 23 },
-  "t::spec::packages::RequireAndUse3", { $^a != 23 },
+  "packages::RequireAndUse1", { $^a == 42 },
+  "packages::RequireAndUse2", { $^a != 23 },
+  "packages::RequireAndUse3", { $^a != 23 },
 );
 
 for @tests -> $mod, $expected_ret {
@@ -36,15 +36,15 @@ for @tests -> $mod, $expected_ret {
 our $loaded   = 0;
 our $imported = 0;
 
-EVAL q{use t::spec::packages::LoadCounter; 1} orelse die "error loading package: $!";
+EVAL q{use packages::LoadCounter; 1} orelse die "error loading package: $!";
 is($loaded,   1, "use loads a module");
 is($imported, 1, "use calls &import");
 
-EVAL q{use t::spec::packages::LoadCounter; 1} orelse die "error loading package: $!";
+EVAL q{use packages::LoadCounter; 1} orelse die "error loading package: $!";
 is($loaded,   1, "a second use doesn't load the module again");
 is($imported, 2, "a second use does call &import again");
 
-EVAL q{no t::spec::packages::LoadCounter; 1} orelse die "error no'ing package: $!";
+EVAL q{no packages::LoadCounter; 1} orelse die "error no'ing package: $!";
 is($loaded,   1, "&no doesn't load the module again");
 is($imported, 1, "&no calls &unimport");
 

--- a/S10-packages/require-and-use.t
+++ b/S10-packages/require-and-use.t
@@ -1,7 +1,7 @@
 use v6;
 
 # L<S11/Runtime Importation>
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S10-packages/scope.t
+++ b/S10-packages/scope.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib '.';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 
@@ -27,56 +27,56 @@ plan 23;
     }
 }
 
-use t::spec::packages::PackageTest;
+use PackageTest;
 
 # test that all the functions are in the right place
 
 # sanity test
 # L<S10/Packages/package for Perl>
-is($?PACKAGE, "Main", 'The Main $?PACKAGE was not broken by any declarations');
+is($?PACKAGE.^name, "GLOBAL", 'The Main $?PACKAGE was not broken by any declarations');
 
 # block level
 is(Test1::ns, "Test1", "block-level package declarations");
-cmp-ok(Test1::pkg, &infix:<===>, ::Test1::, 'block-level $?PACKAGE var');
+cmp-ok(Test1::pkg, &infix:<===>, ::Test1, 'block-level $?PACKAGE var');
 dies-ok { EVAL 'test1_export' }, "export was not imported implicitly";
 
 # declared packages
 is(Test2::ns, "Test2", "declared package");
-cmp-ok(Test2::pkg, &infix:<===>, ::Test2::, 'declared package $?PACKAGE');
+cmp-ok(Test2::pkg, &infix:<===>, ::Test2, 'declared package $?PACKAGE');
 
 # string EVAL'ed packages
-is(Test3::pkg, ::Test3::, 'EVAL\'ed package $?PACKAGE');
-cmp-ok(Test3::pkg, &infix:<===>, ::Test3::, 'EVAL\'ed package type object');
+is(Test3::pkg, ::Test3, 'EVAL\'ed package $?PACKAGE');
+cmp-ok(Test3::pkg, &infix:<===>, ::Test3, 'EVAL\'ed package type object');
 
 # this one came from t/packages/Test.pm
-is(t::spec::packages::PackageTest::ns, "t::packages::PackageTest", "loaded package");
-cmp-ok(t::spec::packages::PackageTest::pkg, &infix:<===>, ::t::packages::PackageTest::, 'loaded package $?PACKAGE object');
+is(PackageTest::ns, "PackageTest", "loaded package");
+cmp-ok(PackageTest::pkg, &infix:<===>, PackageTest, 'loaded package $?PACKAGE object');
 my $x;
 lives-ok { $x = test_export() }, "export was imported successfully";
 is($x, "party island", "exported OK");
 
 # exports
-dies-ok { ns() }, "no ns() leaked";
+dies-ok { ::("&ns")() }, "no ns() leaked";
 
 # now the lexical / file level packages...
 my $pkg;
 dies-ok  { $pkg = Our::Package::pkg },
     "Can't see `our' packages out of scope";
-lives-ok { $pkg = t::spec::packages::PackageTest::get_our_pkg() },
+lives-ok { $pkg = PackageTest::get_our_pkg() },
     "Package in scope can see `our' package declarations";
-is($pkg, Our::Package, 'correct $?PACKAGE');
-ok(!($pkg === ::Our::Package),
+is($pkg, PackageTest::Our::Package, 'correct $?PACKAGE');
+ok(!($pkg === ::('Package::Our::Package')),
    'not the same as global type object');
 
 # oh no, how do we get to that object, then?
-# perhaps %t::spec::packages::PackageTest::<Our::Package> ?
+# perhaps %PackageTest::<Our::Package> ?
 
-dies-ok { $pkg = t::spec::packages::PackageTest::cant_see_pkg() },
+dies-ok { $pkg = PackageTest::cant_see_pkg() },
     "can't see package declared out of scope";
-lives-ok { $pkg = t::spec::packages::PackageTest::my_pkg() },
+lives-ok { $pkg = PackageTest::my_pkg() },
     "can see package declared in same scope";
-is($pkg, ::My::Package::, 'correct $?PACKAGE');
-ok($pkg !=== ::*My::Package::, 'not the same as global type object');
+is($pkg.^name, 'PackageTest::My::Package', 'correct $?PACKAGE');
+ok($pkg !=== ::('PackageTest::My::Package'), 'not the same as global type object');
 
 # Check temporization of variables in external packages
 {

--- a/S10-packages/use-with-class.t
+++ b/S10-packages/use-with-class.t
@@ -1,7 +1,7 @@
 use v6;
 use MONKEY-TYPING;
 
-use lib '.', 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 
@@ -11,7 +11,7 @@ plan 11;
 
 # test that 'use' imports class names defined in imported packages
 
-use t::spec::packages::UseTest;
+use UseTest;
 
 ok Stupid::Class.new(), 'can instantiate object of "imported" class';
 
@@ -55,11 +55,13 @@ ok Stupid::Class.new(), 'can instantiate object of "imported" class';
 
 # RT #126302
 {
-    my $p = run :out, :err, $*EXECUTABLE, '-It/spec/packages', '-e',
+    my $package-lib-prefix = $?FILE.IO.parent(2).add("packages").absolute;
+
+    my $p = run :out, :err, $*EXECUTABLE, '-I', $package-lib-prefix, '-e',
         'use RT126302; say "RT126302-OK"';
 
-    like   $p.out.slurp, /'RT126302-OK'/, 'packages compile successfully'; unlike $p.err.slurp, /'src/Perl6/World.nqp'/,
-        'no Perl6/World.nqp in warning';
+    like   $p.out.slurp(:close), /'RT126302-OK'/, 'packages compile successfully';
+    unlike $p.err.slurp(:close), /'src/Perl6/World.nqp'/, 'no Perl6/World.nqp in warning';
 }
 
 # vim: ft=perl6

--- a/S11-compunit/rt126904.t
+++ b/S11-compunit/rt126904.t
@@ -3,7 +3,9 @@ use Test;
 
 plan 1;
 
-my $proc = run $*EXECUTABLE, '-I', 't/spec/packages/RT126904/lib', '-e',
+my $lib-path = $?FILE.IO.parent(2).add('packages/RT126904/lib').absolute;
+
+my $proc = run $*EXECUTABLE, '-I', $lib-path, '-e',
   'use Woohoo::Foo::Bar; use Woohoo::Foo::Baz; my Woohoo::Foo::Bar $bar;',
   :err;
 

--- a/S11-modules/export.t
+++ b/S11-modules/export.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S11-modules/import-tag.t
+++ b/S11-modules/import-tag.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib '.';
+use lib $?FILE.IO.parent(2).child("packages");
 
 use Test;
 
@@ -9,7 +9,7 @@ plan 12;
 # L<S11/"Compile-time Importation"/>
 
 {
-    use t::spec::packages::S11-modules::Foo :others;
+    use S11-modules::Foo :others;
 
     dies-ok { EVAL 'foo()' }, 'foo() not imported - not tagged :others';
 

--- a/S11-modules/importing.t
+++ b/S11-modules/importing.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib '.', 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 
@@ -9,7 +9,7 @@ plan 17;
 # L<S11/"Compile-time Importation"/>
 
 {
-    use t::spec::packages::S11-modules::Foo;
+    use S11-modules::Foo;
 
     ok( &foo, 'Foo::foo is defined (explicitly :DEFAULT)' );
     is( foo(), 'Foo::foo', 'Foo::foo is the sub we expect' );
@@ -48,13 +48,13 @@ dies-ok( { EVAL '&foo' }, 'Foo::foo is undefined in outer scope' );
 
 {
     lives-ok {
-        use t::spec::packages::S11-modules::ExportsEnumDate;
+        use S11-modules::ExportsEnumDate;
     }
 }
 
 # RT #125846
-throws-like 'use t::spec::packages::S11-modules::Foo :NoSucTag;', X::Import::NoSuchTag,
-                :source-package<t::spec::packages::S11-modules::Foo>,
+throws-like 'use S11-modules::Foo :NoSucTag;', X::Import::NoSuchTag,
+                :source-package<S11-modules::Foo>,
                 :tag<NoSucTag>,
              'die while trying to import a non-existent export tag';
 

--- a/S11-modules/lexical.t
+++ b/S11-modules/lexical.t
@@ -1,18 +1,18 @@
 use v6;
 
-use lib '.';
+use lib $?FILE.IO.parent(2).child("packages");
 
 use Test;
 plan 3;
 
 {
-    use t::spec::packages::S11-modules::Foo;
+    use S11-modules::Foo;
     is foo(), 'Foo::foo', 'could import foo()';
 }
 dies-ok {EVAL('foo()') }, 'sub is only imported into the inner lexical scope';
 
 {
-    use t::spec::packages::S11-modules::EmptyClass;
+    use S11-modules::EmptyClass;
     my EmptyClass $foo;
 }
 dies-ok {EVAL('my EmptyClass $bar')}, 'Package is only imported into the inner lexical scope';

--- a/S11-modules/need.t
+++ b/S11-modules/need.t
@@ -1,14 +1,14 @@
 use v6;
 
-use lib '.';
+use lib $?FILE.IO.parent(2);
 
 use Test;
 plan 2;
 
 {
-    need t::spec::packages::Export_PackA;
+    need packages::Export_PackA;
 
-    is t::spec::packages::Export_PackA::exported_foo(),
+    is packages::Export_PackA::exported_foo(),
        42, 'Can "need" a module';
     throws-like 'exported_foo()',
         X::Undeclared::Symbols, '"need" did not import the default export list';

--- a/S11-modules/nested.t
+++ b/S11-modules/nested.t
@@ -1,6 +1,7 @@
 use v6;
-use lib 't/spec/packages';
-use lib 't/spec/packages/S11-modules';
+use lib $?FILE.IO.parent(2).add("packages");
+use lib $?FILE.IO.parent(2).add("packages").add("S11-modules");
+
 use Test;
 plan 11;
 

--- a/S11-modules/perl6lib.t
+++ b/S11-modules/perl6lib.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S11-modules/re-export.t
+++ b/S11-modules/re-export.t
@@ -1,7 +1,9 @@
 use v6;
 use Test;
 
-plan 8;
+use lib $?FILE.IO.parent(2).add("packages").add("S11-modules");
+
+plan 3;
 
 # L<S11/"Compile-time Importation"/"In the absence of a specific scoping specified by the caller">
 

--- a/S11-modules/require.t
+++ b/S11-modules/require.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib $?FILE.IO.parent.parent, $?FILE.IO.parent.child("lib").Str;
+use lib $?FILE.IO.parent(2), $?FILE.IO.parent.add("lib");
 
 use MONKEY-SEE-NO-EVAL;
 
@@ -39,7 +39,8 @@ my $name = 'S11-modules/InnerModule.pm';
 # RT #127233
 {
     require S11-modules::NoModule <&bar>;
-    is bar(),'NoModule::bar','can import symbol not inside module';
+    my $result = bar();
+    is $ = bar(),'NoModule::bar','can import symbol not inside module';
 }
 
 # L<S11/"Runtime Importation"/"To specify both a module name and a filename, use a colonpair">
@@ -54,7 +55,8 @@ throws-like { require InnerModule:file($name) <quux> },
 '&-less import of sub does not produce `Null PMC access` error';
 
 # no need to do that at compile time, since require() really is run time
-PROCESS::<$REPO> := CompUnit::Repository::FileSystem.new(:prefix<t/spec/packages>, :next-repo($*REPO));
+PROCESS::<$REPO> := CompUnit::Repository::FileSystem.new(:next-repo($*REPO),
+    :prefix($?FILE.IO.parent(2).child('packages').relative));
 
 # Next line is for final test.
 GLOBAL::<$x> = 'still here';
@@ -86,7 +88,7 @@ is GLOBAL::<$x>, 'still here', 'loading modules does not clobber GLOBAL';
 
 # tests the combination of chdir+require
 my $cwd = $*CWD;
-lives-ok { chdir "t/spec/packages"; require "Foo.pm"; },
+lives-ok { chdir $?FILE.IO.parent(2).child('packages'); require "Foo.pm"; },
          'can change directory and require a module';
 chdir $cwd;
 

--- a/S11-modules/runtime.t
+++ b/S11-modules/runtime.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages/S11-modules';
+use lib $?FILE.IO.parent(2).add("packages").add("S11-modules");
 
 use Test;
 plan 1;

--- a/S11-repository/curli-install.t
+++ b/S11-repository/curli-install.t
@@ -1,5 +1,5 @@
 use v6;
-constant $path = 't/spec/packages/curi-install';
+constant $path = $?FILE.IO.parent(2).child('packages/curi-install').absolute;
 use lib "inst#$path";
 
 use Test;
@@ -17,10 +17,11 @@ $path.IO.mkdir;
     is $*REPO.loaded.elems, 0, 'no compilation units were loaded so far';
 }
 my $dist = Distribution.new(:name<Foo>);
+my $foo-path = $path.IO.parent.child('Foo.pm').relative;
 
-$*REPO.install($dist, { Foo => 't/spec/packages/Foo.pm' });
+$*REPO.install($dist, { Foo => $foo-path });
 
-throws-like { EVAL q[$*REPO.install($dist, { Foo => 't/spec/packages/Foo.pm' })] },
+throws-like { EVAL '$*REPO.install($dist, { Foo => "' ~ $foo-path ~ '" })' },
     X::AdHoc,
     message => "$dist already installed",
     "cannot reinstall the very same distribution";

--- a/S12-attributes/class.t
+++ b/S12-attributes/class.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S12-class/literal.t
+++ b/S12-class/literal.t
@@ -1,14 +1,12 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 
 plan 2;
 
 # L<S12/Classes/"class or type name using">
-
-# TODO: move that to t/spec/ as well
 
 # Testing class literals
 use  Foo;

--- a/S12-class/stubs.t
+++ b/S12-class/stubs.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S12-construction/BUILD.t
+++ b/S12-construction/BUILD.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S12-meta/classhow.t
+++ b/S12-meta/classhow.t
@@ -1,6 +1,6 @@
 use Test;
 
-use lib '.';
+use lib $?FILE.IO.parent, $?FILE.IO.parent(2).add("packages");
 
 plan 4;
 
@@ -18,7 +18,7 @@ plan 4;
 
 # RT #125135
 {
-    use t::spec::S12-meta::TestHOW;
+    use TestHOW;
 
     class TestClass {
         method one {}

--- a/S12-meta/exporthow.t
+++ b/S12-meta/exporthow.t
@@ -1,22 +1,23 @@
 use v6;
-use lib <.  t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
+use lib $?FILE.IO.parent(2);
 use Test;
 use Test::Util;
 
 plan 12;
 
-throws-like { EVAL 'use t::spec::S12-meta::InvalidDirective;' },
+throws-like { EVAL 'use S12-meta::InvalidDirective;' },
     X::EXPORTHOW::InvalidDirective, directive => 'BBQ';
 
 {
-    use t::spec::S12-meta::Supersede1;
+    use S12-meta::Supersede1;
     class Act { }
     is Act.^tryit(), 'pony', 'Can supersede meta-type for class';
 }
 
 #?rakudo skip 'RT #126759'
 {
-    use t::spec::S12-meta::Supersede1;
+    use S12-meta::Supersede1;
     EVAL q|
        class ActEval { }
        is ActEval.^tryit,'pony','supersede works in EVAL';
@@ -26,22 +27,22 @@ throws-like { EVAL 'use t::spec::S12-meta::InvalidDirective;' },
 class HopefullyUsual { }
 dies-ok { HopefullyUsual.^tryit() }, 'EXPORTHOW::SUPERSEDE is lexical';
 
-throws-like { EVAL 'use t::spec::S12-meta::SupersedeBad;' },
+throws-like { EVAL 'use S12-meta::SupersedeBad;' },
     X::EXPORTHOW::NothingToSupersede, declarator => 'nobody-will-add-this-declarator';
 
-throws-like { EVAL 'use t::spec::S12-meta::Supersede1;
-                    use t::spec::S12-meta::Supersede2;' },
+throws-like { EVAL 'use S12-meta::Supersede1;
+                    use S12-meta::Supersede2;' },
     X::EXPORTHOW::Conflict, directive => 'SUPERSEDE', declarator => 'class';
 
 {
-    use t::spec::S12-meta::Declare;
+    use S12-meta::Declare;
     controller Home { }
     ok Home ~~ Controller, 'Type declared with new controller declarator got Controller role added';
 }
 
 #?rakudo skip 'RT #126759'
 {
-    use t::spec::S12-meta::Declare;
+    use S12-meta::Declare;
     EVAL q|
        controller TestEval { }
        ok TestEval ~~ Controller,'declarator works inside EVAL';
@@ -50,11 +51,11 @@ throws-like { EVAL 'use t::spec::S12-meta::Supersede1;
 
 dies-ok { EVAL 'controller Fat { }' }, 'Imported declarators do not leak out of lexical scope';
 
-throws-like { EVAL 'use t::spec::S12-meta::DeclareBad;' },
+throws-like { EVAL 'use S12-meta::DeclareBad;' },
     X::EXPORTHOW::Conflict, directive => 'DECLARE', declarator => 'class';
 
 {
-    use t::spec::S12-meta::MultiDeclare;
+    use S12-meta::MultiDeclare;
     lives-ok {
         pokemon pikachu { }
         digimon augmon  { }

--- a/S12-methods/parallel-dispatch.t
+++ b/S12-methods/parallel-dispatch.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use ContainsUnicode;

--- a/S12-subset/subtypes.t
+++ b/S12-subset/subtypes.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S13-overloading/operators.t
+++ b/S13-overloading/operators.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S15-literals/numbers.t
+++ b/S15-literals/numbers.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 # S15-literals/numbers.t --- test Unicode (namely non-ASCII) numerals
 
 use Test;

--- a/S15-nfg/GraphemeBreakTest.t
+++ b/S15-nfg/GraphemeBreakTest.t
@@ -1,6 +1,6 @@
 use v6;
-my IO::Path $repo-dir      = "3rdparty/Unicode/9.0.0/ucd/auxiliary/GraphemeBreakTest.txt".IO;
-my IO::Path $rakudo-subdir = "t/spec".IO;
+my IO::Path $repo-dir      = $?FILE.IO.parent(2).add("3rdparty/Unicode/9.0.0/ucd/auxiliary/GraphemeBreakTest.txt");
+my IO::Path $rakudo-subdir = $?FILE.IO.parent(2);
 my IO::Path $rakudo-dir    = $rakudo-subdir.child($repo-dir);
 my Str:D    $location      = $rakudo-dir.e ?? $rakudo-dir.Str !! $repo-dir.Str;
 our $DEBUG;

--- a/S15-nfg/concat-stable.t
+++ b/S15-nfg/concat-stable.t
@@ -4,11 +4,8 @@ use Test;
 # https://creativecommons.org/licenses/by-sa/3.0/
 # See Retreived.txt for dates and URL's they were retreived from
 sub MAIN (:$scripts = <Hangul Arabic Tibetan>, Int:D :$repeat = 1, Bool:D :$no-test-concat = False) {
-    my IO::Path $path = "t/spec/3rdparty/wikipedia".IO.d
-                ?? "t/spec/3rdparty/wikipedia".IO
-            !! "3rdparty/wikipedia".IO.d
-                ?? "3rdparty/wikipedia".IO
-                !! die("Could not find t/spec/3rdparty/wikipedia or 3rdparty/wikipedia");
+    my IO::Path $path = $?FILE.IO.parent(2).add("3rdparty/wikipedia");
+    die("Could not 3rdparty/wikipedia") unless $path.e && $path.d;
     plan 7 * $scripts.elems;
     for $scripts.words -> $script {
         my $text = $path.child("$script.txt").slurp;

--- a/S16-filehandles/argfiles.t
+++ b/S16-filehandles/argfiles.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S16-filehandles/dir.t
+++ b/S16-filehandles/dir.t
@@ -1,7 +1,8 @@
 use v6;
 use Test;
-use FindBin;
 plan 36;
+
+my $bin = $?FILE.IO.parent;
 
 # L<S32::IO/IO::DirectoryNode>
 # old: L<S16/"Filehandles, files, and directories"/"IO::Dir::open">
@@ -18,8 +19,8 @@ opendir/readdir support
 
 =end pod
 
-my $dir = opendir($FindBin::Bin);
-isa-ok($dir, IO::Dir, "opendir worked on $FindBin::Bin");
+my $dir = opendir($bin);
+isa-ok($dir, IO::Dir, "opendir worked on $bin");
 
 my @files = readdir($dir);
 ok(@files, "seems readdir worked too");
@@ -35,7 +36,7 @@ is($rew_1, 1, "success of rewinddir 1 returns 1");
 
 my @files_again = readdir($dir);
 
-is-deeply(\@files_again, @files, "same list of files retrieved after rewind");
+is-deeply(@files_again, @files, "same list of files retrieved after rewind");
 
 my $rew_2 = rewinddir($dir);
 is($rew_2, 1, "success of rewinddir 2 returns 1");
@@ -45,12 +46,12 @@ loop {
     my $f = readdir($dir) orelse last;
     @files_scalar.push($f);
 }
-is-deeply(\@files_scalar, @files, "same list of files retrieved after rewind, using scalar context");
+is-deeply(@files_scalar, @files, "same list of files retrieved after rewind, using scalar context");
 
 my $rew_3 = $dir.rewinddir;
 is($rew_3, 1, 'success of rewinddir 3 using $dir.rewinddir returns 1');
 my @files_dot = $dir.readdir;
-is-deeply(\@files_dot, @files, 'same list of files retrieved using $dir.readdir');
+is-deeply(@files_dot, @files, 'same list of files retrieved using $dir.readdir');
 
 my $rew_4 = $dir.rewinddir;
 is($rew_4, 1, 'success of rewinddir 4 using $dir.rewinddir returns 1');
@@ -59,7 +60,7 @@ my @files_scalar_dot;
 for $dir.readdir -> $f {
     @files_scalar_dot.push($f);
 }
-is-deeply(\@files_scalar_dot, @files, 'same list of files, using $dir.readdir in scalar context');
+is-deeply(@files_scalar_dot, @files, 'same list of files, using $dir.readdir in scalar context');
 
 my @more_files_2 = $dir.readdir;
 is(+@more_files_2, 0, "No more things to read");
@@ -77,7 +78,7 @@ ok(closedir($dir), "as does closedir");
 # closedir
 
 
-my $dh = opendir($FindBin::Bin);
+my $dh = opendir($bin);
 isa-ok($dh, IO::Dir, "opendir worked");
 my @files_once_more = $dh.readdir;
 is-deeply(@files_once_more.sort, @files.sort, 'same list of files,after reopen');
@@ -87,8 +88,8 @@ ok($dir.closedir, 'closedir using $dir.closedir format');
 # short version. read close etc...
 # copied from above just shortent he methods. and append _s to every variable.
 diag "Start testing for short version.";
-my $dir_s = opendir($FindBin::Bin);
-isa-ok($dir_s, IO::Dir, "opendir worked on $FindBin::Bin");
+my $dir_s = opendir($bin);
+isa-ok($dir_s, IO::Dir, "opendir worked on $bin");
 
 my @files_s = read($dir_s);
 ok(@files_s, "seems read worked too");
@@ -104,7 +105,7 @@ is($rew_1_s, 1, "success of rewind 1 returns 1");
 
 my @files_again_s = read($dir_s);
 
-is-deeply(\@files_again_s, @files_s, "same list of files retrieved after rewind");
+is-deeply(@files_again_s, @files_s, "same list of files retrieved after rewind");
 
 my $rew_2_s = rewind($dir_s);
 is($rew_2_s, 1, "success of rewind 2 returns 1");
@@ -114,12 +115,12 @@ loop {
     my $f = read($dir_s) orelse last;
     @files_scalar_s.push($f);
 }
-is-deeply(\@files_scalar_s, @files_s, "same list of files retrieved after rewind, using scalar context");
+is-deeply(@files_scalar_s, @files_s, "same list of files retrieved after rewind, using scalar context");
 
 my $rew_3_s = $dir_s.rewind;
 is($rew_3_s, 1, 'success of rewind 3 using $dir.rewind returns 1');
 my @files_dot_s = $dir_s.read;
-is-deeply(\@files_dot_s, @files_s, 'same list of files retrieved using $dir.read');
+is-deeply(@files_dot_s, @files_s, 'same list of files retrieved using $dir.read');
 
 my $rew_4_s = $dir_s.rewind;
 is($rew_4_s, 1, 'success of rewind 4 using $dir.rewind returns 1');
@@ -128,7 +129,7 @@ my @files_scalar_dot_s;
 for $dir_s.read -> $f {
     @files_scalar_dot_s.push($f);
 }
-is-deeply(\@files_scalar_dot_s, @files, 'same list of files, using $dir.read in scalar context');
+is-deeply(@files_scalar_dot_s, @files, 'same list of files, using $dir.read in scalar context');
 
 my @more_files_2_s = $dir_s.read;
 is(+@more_files_2_s, 0, "No more things to read");
@@ -145,7 +146,7 @@ ok(close($dir_s), "as does close");
 # rewinddir($dir);
 # closedir
 
-my $dh_s = opendir($FindBin::Bin);
+my $dh_s = opendir($bin);
 isa-ok($dh_s, IO::Dir, "opendir worked");
 my @files_once_more_s = $dh_s.read;
 is-deeply(@files_once_more_s.sort, @files_s.sort, 'same list of files,after reopen');

--- a/S16-filehandles/filetest.t
+++ b/S16-filehandles/filetest.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S16-filehandles/io.t
+++ b/S16-filehandles/io.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S16-filehandles/misc.t
+++ b/S16-filehandles/misc.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S16-io/bare-say.t
+++ b/S16-io/bare-say.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S16-io/basic-open.t
+++ b/S16-io/basic-open.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 
@@ -17,7 +17,7 @@ sub test_lines(@lines) {
 }
 
 {
-    my $fh = open('t/spec/S16-io/test-data');
+    my $fh = open($?FILE.IO.parent.child('test-data'));
     my $count = 0;
     while !$fh.eof {
         my $x = $fh.get;
@@ -28,7 +28,7 @@ sub test_lines(@lines) {
 
 # test that we can interate over $fh.lines
 {
-    my $fh =  open('t/spec/S16-io/test-data');
+    my $fh =  open($?FILE.IO.parent.child('test-data'));
 
     ok defined($fh), 'Could open test file';
     my @lines;
@@ -40,7 +40,7 @@ sub test_lines(@lines) {
 
 # test that we can get all items in list context:
 {
-    my $fh =  open('t/spec/S16-io/test-data');
+    my $fh =  open($?FILE.IO.parent.child('test-data'));
     ok defined($fh), 'Could open test file (again)';
     my @lines = $fh.lines;
     test_lines(@lines);

--- a/S16-io/comb.t
+++ b/S16-io/comb.t
@@ -3,7 +3,7 @@ use Test;
 
 plan 25;
 
-my $filename = 't/spec/S16-io/comb.testing';
+my $filename = $?FILE.IO.parent.child('comb.testing');
 
 #?DOES 1
 sub test-comb($text,@result,|c) {

--- a/S16-io/eof.t
+++ b/S16-io/eof.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S16-io/handles-between-threads.t
+++ b/S16-io/handles-between-threads.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S16-io/home.t
+++ b/S16-io/home.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S16-io/lines.t
+++ b/S16-io/lines.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 
@@ -13,7 +13,7 @@ my @endings =
 
 plan 8 + @endings * (1 + 3 * ( 5 + 6));
 
-my $filename = 't/spec/S16-io/lines.testing';
+my $filename = $?FILE.IO.parent.child('lines.testing');
 my @text = <zero one two three four>;
 
 for @endings -> (:key($eol), :value($EOL)) {
@@ -79,7 +79,7 @@ unlink $filename; # cleanup
 
 {
     # RT #130430
-    my $file = 't/spec/S16-io/lines.testing'.IO;
+    my $file = $?FILE.IO.parent.child('lines.testing');
     $file.spurt: join "\n", <a b c>;
     is-deeply $file.lines(2000), ('a', 'b', 'c'),
         'we stop when data ends, even if limit has not been reached yet';
@@ -88,7 +88,7 @@ unlink $filename; # cleanup
 
 {
     # https://irclog.perlgeek.de/perl6-dev/2017-01-21#i_13962764
-    my $file = 't/spec/S16-io/lines.testing'.IO;
+    my $file = $?FILE.IO.parent.child('lines.testing');
     $file.spurt: join "\n", <a b c>;
     is_run 'lines; lines', :args[$file], {
         :out(''), :err(''), :0status,

--- a/S16-io/print.t
+++ b/S16-io/print.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S16-io/prompt.t
+++ b/S16-io/prompt.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S16-io/put.t
+++ b/S16-io/put.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S16-io/say-and-ref.t
+++ b/S16-io/say-and-ref.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S16-io/split.t
+++ b/S16-io/split.t
@@ -3,7 +3,7 @@ use Test;
 
 plan 18;
 
-my $filename = 't/spec/S16-io/split.testing';
+my $filename = $?FILE.IO.parent.child('split.testing');
 
 sub test-split($text,@result,|c) {
     subtest {

--- a/S16-io/supply.t
+++ b/S16-io/supply.t
@@ -1,10 +1,10 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;
 
-my $filename = 't/spec/S16-io/supply.testing';
+my $filename = $?FILE.IO.parent.child('supply.testing');
 
 plan 7;
 

--- a/S16-io/words.t
+++ b/S16-io/words.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S16-unfiled/getpeername.t
+++ b/S16-unfiled/getpeername.t
@@ -12,7 +12,7 @@ IO.getpeername test
 
 plan 1;
 
-my $sock = connect('google.com', 80);
-ok $sock.getpeername.defined, "IO.getpeer works";
+my $sock = IO::Socket::INET.connect('google.com', 80);
+ok $sock.getpeername.defined, "IO::Socket::INet.getpeername works";
 
 # vim: ft=perl6

--- a/S17-procasync/kill.t
+++ b/S17-procasync/kill.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S17-procasync/stress.t
+++ b/S17-procasync/stress.t
@@ -1,6 +1,5 @@
 use v6;
-use lib <packages/>;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 
@@ -8,7 +7,7 @@ plan 23;
 
 # RT #125515
 {
-    constant $read-file = "t/spec/packages/README".IO.f ?? "t/spec/packages/README".IO !! "packages/README".IO;
+    constant $read-file = $?FILE.IO.parent(2).add("packages/README");
     $read-file.IO.r or bail-out "Missing $read-file that is needed to run a test";
 
     my @got;

--- a/S17-promise/at.t
+++ b/S17-promise/at.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S17-promise/basic.t
+++ b/S17-promise/basic.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S17-supply/basic.t
+++ b/S17-supply/basic.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S17-supply/batch.t
+++ b/S17-supply/batch.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/categorize.t
+++ b/S17-supply/categorize.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/classify.t
+++ b/S17-supply/classify.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/delayed.t
+++ b/S17-supply/delayed.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/do.t
+++ b/S17-supply/do.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/elems.t
+++ b/S17-supply/elems.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/flat.t
+++ b/S17-supply/flat.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/from-list.t
+++ b/S17-supply/from-list.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/grab.t
+++ b/S17-supply/grab.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/grep.t
+++ b/S17-supply/grep.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/head.t
+++ b/S17-supply/head.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/interval.t
+++ b/S17-supply/interval.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/lines.t
+++ b/S17-supply/lines.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/map.t
+++ b/S17-supply/map.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/max.t
+++ b/S17-supply/max.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/merge.t
+++ b/S17-supply/merge.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/min.t
+++ b/S17-supply/min.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/minmax.t
+++ b/S17-supply/minmax.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/on-demand.t
+++ b/S17-supply/on-demand.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/produce.t
+++ b/S17-supply/produce.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/reduce.t
+++ b/S17-supply/reduce.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/reverse.t
+++ b/S17-supply/reverse.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/rotor.t
+++ b/S17-supply/rotor.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/schedule-on.t
+++ b/S17-supply/schedule-on.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/skip.t
+++ b/S17-supply/skip.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/sort.t
+++ b/S17-supply/sort.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/squish.t
+++ b/S17-supply/squish.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/stable.t
+++ b/S17-supply/stable.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/tail.t
+++ b/S17-supply/tail.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/throttle.t
+++ b/S17-supply/throttle.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S17-supply/unique.t
+++ b/S17-supply/unique.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/words.t
+++ b/S17-supply/words.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/zip-latest.t
+++ b/S17-supply/zip-latest.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S17-supply/zip.t
+++ b/S17-supply/zip.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Tap;

--- a/S19-command-line-options/02-dash-n.t
+++ b/S19-command-line-options/02-dash-n.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S19-command-line-options/03-dash-p.t
+++ b/S19-command-line-options/03-dash-p.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S19-command-line-options/04-negation.t
+++ b/S19-command-line-options/04-negation.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S19-command-line-options/05-delimited-options.t
+++ b/S19-command-line-options/05-delimited-options.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S19-command-line/arguments.t
+++ b/S19-command-line/arguments.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S19-command-line/dash-e.t
+++ b/S19-command-line/dash-e.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 plan 4;

--- a/S19-command-line/help.t
+++ b/S19-command-line/help.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 plan 1;

--- a/S19-command-line/repl.t
+++ b/S19-command-line/repl.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S24-testing/1-basic.t
+++ b/S24-testing/1-basic.t
@@ -1,7 +1,5 @@
 use v6;
 
-use lib <ext/Test>; # Hack if we're run from make smoke
-
 use Test;
 
 plan 60;
@@ -112,7 +110,8 @@ cmp-ok('test', sub ($a, $b) { ?($a gt $b) }, 'you', :desc('... testing gt on two
 
 ## use-ok
 
-use-ok('t::use_ok_test');
+use lib $?FILE.IO.parent;
+use-ok('use_ok_test');
 
 # Need to do a test loading a package that is not there,
 # and see that the load fails. Gracefully. :)

--- a/S24-testing/11-plan-skip-all-subtests.t
+++ b/S24-testing/11-plan-skip-all-subtests.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 4;

--- a/S24-testing/12-subtest-todo.t
+++ b/S24-testing/12-subtest-todo.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S24-testing/13-cmp-ok.t
+++ b/S24-testing/13-cmp-ok.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S24-testing/3-output.t
+++ b/S24-testing/3-output.t
@@ -2,7 +2,7 @@
 
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;
@@ -41,7 +41,7 @@ plan 6;
         'eval error via diag';
 }
 
-my $test-file = 't/spec/S24-testing/test-data/todo-passed.txt';
+my $test-file = $?FILE.IO.parent.add('test-data/todo-passed.txt');
 my $cmd = "$*EXECUTABLE $test-file 2>&1";
 ok qqx[$cmd] ~~ /^"1..1" \n "ok 1 - test passes" \s* "# TODO testing output for passing todo test" \n $ /,
     "expected output with passing todo test";

--- a/S24-testing/7-bail_out.t
+++ b/S24-testing/7-bail_out.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 4;

--- a/S24-testing/8-die_on_fail.t
+++ b/S24-testing/8-die_on_fail.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 6;

--- a/S24-testing/9-is_deeply.t
+++ b/S24-testing/9-is_deeply.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S24-testing/line-numbers.t
+++ b/S24-testing/line-numbers.t
@@ -3,12 +3,12 @@ use Test;
 
 plan 13;
 
-my $dir    = 't/spec/S24-testing/test-data/';
+my $dir    = $?FILE.IO.parent.add('test-data');
 my $prefix = 'line-number-';
 my $suffix = '.txt';
 
 sub execute-test ( :$function, :$line ) {
-    my $full-path = $dir ~ $prefix ~ $function ~ $suffix;
+    my $full-path = $dir.add($prefix ~ $function ~ $suffix);
     my $proc = run($*EXECUTABLE, $full-path, :!out, :err);
     like $proc.err.slurp,
         /'Failed test ' (\N* \n \N*)? 'at ' $full-path ' line ' $line/,

--- a/S24-testing/test-data/README
+++ b/S24-testing/test-data/README
@@ -1,4 +1,4 @@
-t/spec/S24-testing/test-data/README
+S24-testing/test-data/README
 
 This directory exists to hold files which are used
 by tests in S24-testing.

--- a/S26-documentation/02-paragraph.t
+++ b/S26-documentation/02-paragraph.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 28;

--- a/S26-documentation/10-doc-cli.t
+++ b/S26-documentation/10-doc-cli.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S29-context/die.t
+++ b/S29-context/die.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S29-context/eval.t
+++ b/S29-context/eval.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use nqp;
 use Test;
 use Test::Util;

--- a/S29-context/evalfile.t
+++ b/S29-context/evalfile.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S29-context/exit.t
+++ b/S29-context/exit.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S29-context/sleep.t
+++ b/S29-context/sleep.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S29-os/system.t
+++ b/S29-os/system.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S32-basics/warn.t
+++ b/S32-basics/warn.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S32-exceptions/misc.t
+++ b/S32-exceptions/misc.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib "t/spec/packages";
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S32-hash/iterator.t
+++ b/S32-hash/iterator.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Iterator;
 
 plan 4 * 7;

--- a/S32-hash/perl.t
+++ b/S32-hash/perl.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Idempotence;

--- a/S32-io/IO-Socket-Async.t
+++ b/S32-io/IO-Socket-Async.t
@@ -150,7 +150,7 @@ $echoTap.close;
 }
 
 {
-    my Buf $binary = slurp( 't/spec/S32-io/socket-test.bin', bin => True );
+    my Buf $binary = slurp( $?FILE.IO.parent.child('socket-test.bin'), bin => True );
     my $binaryTap = $server.tap(-> $c {
         $c.write($binary).then({ $c.close });
     });

--- a/S32-io/chdir-process.t
+++ b/S32-io/chdir-process.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/chdir.t
+++ b/S32-io/chdir.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/copy.t
+++ b/S32-io/copy.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/dir.t
+++ b/S32-io/dir.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/file-tests.t
+++ b/S32-io/file-tests.t
@@ -1,7 +1,7 @@
 #! /usr/bin/env perl6
 
 use v6.c;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S32-io/indir.t
+++ b/S32-io/indir.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <lib t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/io-cathandle.t
+++ b/S32-io/io-cathandle.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/io-handle.t
+++ b/S32-io/io-handle.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/io-path-symlink.t
+++ b/S32-io/io-path-symlink.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/io-path.t
+++ b/S32-io/io-path.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/lock.t
+++ b/S32-io/lock.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <lib t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/mkdir_rmdir.t
+++ b/S32-io/mkdir_rmdir.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S32-io/move.t
+++ b/S32-io/move.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/note.t
+++ b/S32-io/note.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S32-io/null-char.t
+++ b/S32-io/null-char.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/open.t
+++ b/S32-io/open.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/other.t
+++ b/S32-io/other.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S32-io/out-buffering.t
+++ b/S32-io/out-buffering.t
@@ -1,4 +1,4 @@
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/seek.t
+++ b/S32-io/seek.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/slurp.t
+++ b/S32-io/slurp.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/spurt.t
+++ b/S32-io/spurt.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages/>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-io/tell.t
+++ b/S32-io/tell.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-list/iterator.t
+++ b/S32-list/iterator.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test::Iterator;
 
 plan 9 * 6;

--- a/S32-list/join.t
+++ b/S32-list/join.t
@@ -145,7 +145,7 @@ is(("hi",).join("!"), "hi", "&join works with one-element lists (3)");
 ## : Fallback semantics in S12 suggest that since no matching multi method is
 ## : found, subs are tried - that is, the expression is interpreted as
 ## :    join('str', 'other_str')
-## : yielding 'other_str'. t/spec/S32::Containers-list/join.t disagrees, and wants the
+## : yielding 'other_str'. S32::Containers-list/join.t disagrees, and wants the
 ## : result to be 'str'.
 ##
 ## I want the result to be 'str'.

--- a/S32-list/minmax.t
+++ b/S32-list/minmax.t
@@ -99,7 +99,7 @@ is min(:by({$^a <=> $^b}), 1,2,3),  1, "subroutine form of min with literals wor
 
 # Try to read numbers from a file
 {
-    my $fh = open "t/spec/S32-list/numbers.data";
+    my $fh = open $?FILE.IO.parent.add("numbers.data");
     @array = $fh.lines();
     is @array.max, 5, "max of strings read from a file works";
     is @array.min, -1, "min of strings read from a file works";

--- a/S32-list/reduce.t
+++ b/S32-list/reduce.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-list/roll.t
+++ b/S32-list/roll.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/S32-num/negative-zero.t
+++ b/S32-num/negative-zero.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 plan 20;

--- a/S32-num/power.t
+++ b/S32-num/power.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-num/rat.t
+++ b/S32-num/rat.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-scalar/perl.t
+++ b/S32-scalar/perl.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Idempotence;

--- a/S32-scalar/undef.t
+++ b/S32-scalar/undef.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S32-str/lines.t
+++ b/S32-str/lines.t
@@ -1,6 +1,6 @@
 use v6;
 
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/S32-str/sprintf.t
+++ b/S32-str/sprintf.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-str/substr.t
+++ b/S32-str/substr.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/S32-str/words.t
+++ b/S32-str/words.t
@@ -1,5 +1,5 @@
 use v6;
-use lib <t/spec/packages>;
+use lib $?FILE.IO.parent(2).add("packages");
 use Test;
 use Test::Util;
 

--- a/integration/advent2009-day12.t
+++ b/integration/advent2009-day12.t
@@ -1,7 +1,7 @@
 # http://perl6advent.wordpress.com/2009/12/12/day-12-modules-and-exporting/
 
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/integration/advent2009-day21.t
+++ b/integration/advent2009-day21.t
@@ -1,7 +1,7 @@
 # http://perl6advent.wordpress.com/2009/12/21/day-21-grammars-and-actions/
 
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 

--- a/integration/advent2011-day07.t
+++ b/integration/advent2011-day07.t
@@ -1,6 +1,6 @@
 #! http://perl6advent.wordpress.com/2011/12/07/grammarprofiler/
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Advent::GrammarProfiler;

--- a/integration/advent2011-day10.t
+++ b/integration/advent2011-day10.t
@@ -1,7 +1,7 @@
 #! http://perl6advent.wordpress.com/2011/12/10/documenting-perl-6/
 
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/integration/advent2011-day14.t
+++ b/integration/advent2011-day14.t
@@ -1,6 +1,6 @@
 # http://perl6advent.wordpress.com/2011/12/14/meta-programming-what-why-and-how/
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 plan 8;

--- a/integration/advent2011-day23.t
+++ b/integration/advent2011-day23.t
@@ -1,6 +1,6 @@
 # http://perl6advent.wordpress.com/2011/12/23/day-23-idiomatic-perl-6/
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/integration/advent2012-day06.t
+++ b/integration/advent2012-day06.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/integration/advent2012-day21.t
+++ b/integration/advent2012-day21.t
@@ -1,7 +1,7 @@
 # http://perl6advent.wordpress.com/2012/12/21/day-21-collatz-variations/
 # more about benchmarking than anything else. Definitely a stress test!
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 plan 9;

--- a/integration/error-reporting.t
+++ b/integration/error-reporting.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 plan 33;
@@ -120,7 +120,7 @@ is_run 'die "foo"; END { say "end run" }',
 # RT #103034
 #?DOES 3
 {
-    use lib 't/spec/packages';
+    use lib $?FILE.IO.parent(2).add("packages");
     use Foo;
     try dies();
     ok $!, 'RT #103034 -- died';

--- a/integration/precompiled.t
+++ b/integration/precompiled.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages', 'packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Compile;

--- a/integration/real-strings.t
+++ b/integration/real-strings.t
@@ -76,7 +76,7 @@ is "helo".substr(0,3).trans, 'hel', 'substr returns P6 strings (RT #76564, RT #7
 }
 
 {
-    my $contents = slurp 't/spec/integration/real-strings.t';
+    my $contents = slurp $?FILE.IO.parent.add('real-strings.t');
     lives-ok {$contents.trans(['t'] => ['T']) }, 
        'Still works with strings returned from slurp() (lives)';
 }

--- a/integration/weird-errors.t
+++ b/integration/weird-errors.t
@@ -1,5 +1,5 @@
 use v6;
-use lib 't/spec/packages';
+use lib $?FILE.IO.parent(2).add("packages");
 
 use Test;
 use Test::Util;

--- a/packages/A/A.pm
+++ b/packages/A/A.pm
@@ -1,5 +1,5 @@
 use v6;
-# used in t/spec/S11-modules/nested.t 
+# used in S11-modules/nested.t
 
 module A::A {
     use A::B;

--- a/packages/A/B.pm
+++ b/packages/A/B.pm
@@ -1,5 +1,5 @@
 use v6;
-# used in t/spec/S11-modules/nested.t 
+# used in S11-modules/nested.t
 
 unit module A::B;
 role B { };

--- a/packages/ArrayInit.pm
+++ b/packages/ArrayInit.pm
@@ -1,7 +1,7 @@
 use v6;
 unit module ArrayInit;
 
-# used by t/spec/S10-packages/basic.t
+# used by S10-packages/basic.t
 
 sub array_init() is export {
     my @array;

--- a/packages/Export_PackA.pm
+++ b/packages/Export_PackA.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module t::spec::packages::Export_PackA {
+module packages::Export_PackA {
   our sub exported_foo () is export {
     42;
   }

--- a/packages/Export_PackB.pm
+++ b/packages/Export_PackB.pm
@@ -1,9 +1,9 @@
 use v6;
 
-module t::spec::packages::Export_PackB {
-  use t::spec::packages::Export_PackA;
+module packages::Export_PackB {
+  use packages::Export_PackA;
 
-  sub does_export_work () {
+  our sub does_export_work () {
     try { exported_foo() } == 42;
   }
 }

--- a/packages/Export_PackC.pm
+++ b/packages/Export_PackC.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module t::spec::packages::Export_PackC {
+module packages::Export_PackC {
   sub foo_packc () is export {
     1;
   }

--- a/packages/Export_PackD.pm
+++ b/packages/Export_PackD.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module t::spec::packages::Export_PackD {
+module packages::Export_PackD {
   sub this_gets_exported_lexically () is export {
     'moose!'
   }

--- a/packages/Import.pm
+++ b/packages/Import.pm
@@ -1,3 +1,3 @@
 use v6;
-unit module t::spec::packages::Import;
+unit module Import;
 # note the absence of a sub import() { }

--- a/packages/LoadCounter.pm
+++ b/packages/LoadCounter.pm
@@ -1,6 +1,6 @@
 use v6;
 
-unit module t::packages::LoadCounter;
+unit module LoadCounter;
 
 $Main::loaded++;
 

--- a/packages/PackageTest.pm
+++ b/packages/PackageTest.pm
@@ -1,35 +1,37 @@
 use v6;
-unit package t::spec::packages::PackageTest;
 
-sub ns  { "t::spec::packages::PackageTest" }
+package PackageTest {
 
-sub pkg { $?PACKAGE }
+    our sub ns  { "PackageTest" }
 
-sub test_export is export { "party island" }
+    our sub pkg { $?PACKAGE }
 
-sub get_our_pkg {
-    Our::Package::pkg();
-}
+    sub test_export is export { "party island" }
 
-our package Our::Package {
+    our package Our::Package {
 
-    sub pkg { $?PACKAGE }
+        our sub pkg { $?PACKAGE }
 
-}
+    }
 
-sub cant_see_pkg {
-    return My::Package::pkg();
-}
 
-{
-    sub my_pkg {
+    our sub get_our_pkg {
+        Our::Package::pkg();
+    }
+
+    sub cant_see_pkg {
         return My::Package::pkg();
     }
 
-    my package My::Package {
-        sub pkg { $?PACKAGE }
+    {
+        my package My::Package {
+            our sub pkg { $?PACKAGE }
+        }
+
+        our sub my_pkg {
+            return My::Package::pkg();
+        }
     }
 
+    sub dummy_sub_with_params($arg1, $arg2) is export { "[$arg1] [$arg2]" }
 }
-
-sub dummy_sub_with_params($arg1, $arg2) is export { "[$arg1] [$arg2]" }

--- a/packages/README
+++ b/packages/README
@@ -1,8 +1,8 @@
-t/spec/packages/README
+packages/README
 
 This directory exists to hold files tested in S10-packages so that there isn't
 a hyphen in the filename of the .pm file. This way, we can just
-    use t::spec::packages::Whatever;
+    use packages::Whatever;
 instead of needing to quote the package name all the time, or add the proper
 directory to the Perl 6 equivalent of @INC.
 

--- a/packages/RT128156/Needed.pm6
+++ b/packages/RT128156/Needed.pm6
@@ -1,1 +1,2 @@
 class Needed {};
+#

--- a/packages/RequireAndUse1.pm
+++ b/packages/RequireAndUse1.pm
@@ -4,7 +4,7 @@ use v6;
 # 42. See thread "What do use and require evaluate to?" on p6l started by Ingo
 # Blechschmidt, L<"http://www.nntp.perl.org/group/perl.perl6.language/22258">.
 
-module t::spec::packages::RequireAndUse1 {
+module packages::RequireAndUse1 {
   23;
 }
 

--- a/packages/RequireAndUse2.pm
+++ b/packages/RequireAndUse2.pm
@@ -4,6 +4,6 @@ use v6;
 # see thread "What do use and require evaluate to?" on p6l started by Ingo
 # Blechschmidt, L<"http://www.nntp.perl.org/group/perl.perl6.language/22258">.
 
-module t::spec::packages::RequireAndUse2 {
+module package::RequireAndUse2 {
   23;
 }

--- a/packages/RequireAndUse3.pm
+++ b/packages/RequireAndUse3.pm
@@ -5,6 +5,6 @@ use v6;
 # started by Ingo Blechschmidt,
 # L<"http://www.nntp.perl.org/group/perl.perl6.language/22258">.
 
-unit module t::spec::packages::RequireAndUse3;
+unit module package::RequireAndUse3;
 
 23;

--- a/packages/S11-modules/Foo.pm
+++ b/packages/S11-modules/Foo.pm
@@ -1,7 +1,7 @@
 use v6;
 # L<S11/"Exportation"/>
 
-unit module t::spec::packages::S11-modules::Foo;
+unit module packages::S11-modules::Foo;
 sub foo is export(:DEFAULT)          { 'Foo::foo' }  #  :DEFAULT, :ALL
 sub bar is export(:DEFAULT, :others) { 'Foo::bar' }  #  :DEFAULT, :ALL, :others
 sub baz is export(:MANDATORY)        { 'Foo::baz' }  #  (always exported)

--- a/packages/Test/Util.pm
+++ b/packages/Test/Util.pm
@@ -126,7 +126,7 @@ our sub run( Str $code, Str $input = '', *%o) {
 }
 
 sub get_out( Str $code, Str $input?, :@args, :@compiler-args) is export {
-    my $fnbase = 'getout';
+    my $fnbase = $*TMPDIR.add('getout').absolute;
     $fnbase ~= '-' ~ $*PID if defined $*PID;
     $fnbase ~= '-' ~ 1_000_000.rand.Int;
 
@@ -152,7 +152,7 @@ sub get_out( Str $code, Str $input?, :@args, :@compiler-args) is export {
         $clobber( "$fnbase.in", $input );
         $clobber( "$fnbase.code", $code ) if defined $code;
 
-        my $cmd = $*EXECUTABLE ~ ' ';
+        my $cmd = $*EXECUTABLE.absolute ~ ' ';
         $cmd ~= @compiler-args.join(' ') ~ ' ' if @compiler-args;
         $cmd ~= $fnbase ~ '.code'  if $code.defined;
         $cmd ~= " @actual_args.join(' ') < $fnbase.in > $fnbase.out 2> $fnbase.err";
@@ -179,7 +179,7 @@ sub get_out( Str $code, Str $input?, :@args, :@compiler-args) is export {
 
 multi doesn't-hang (Str $args, $desc, :$in, :$wait = 5, :$out, :$err)
 is export {
-    doesn't-hang \($*EXECUTABLE, '-e', $args), $desc,
+    doesn't-hang \($*EXECUTABLE.absolute, '-e', $args), $desc,
         :$in, :$wait, :$out, :$err;
 }
 
@@ -303,9 +303,9 @@ sub run-with-tty (
     state $path = make-temp-file.absolute;
     # on MacOS, `script` doesn't take the command via `c` arg
     state $script = shell(:!out, :!err, 'script -t/dev/null -qc "" /dev/null')
-        ?? “script -t/dev/null -qc '"$*EXECUTABLE" "$path"' /dev/null”
-        !! shell(:!out, :!err, “script -q /dev/null "$*EXECUTABLE" -e ""”)
-            ?? “script -q /dev/null "$*EXECUTABLE" "$path"”
+        ?? “script -t/dev/null -qc '"$*EXECUTABLE.absolute()" "$path"' /dev/null”
+        !! shell(:!out, :!err, “script -q /dev/null "$*EXECUTABLE.absolute()" -e ""”)
+            ?? “script -q /dev/null "$*EXECUTABLE.absolute()" "$path"”
             !! do { skip "need `script` command to run test: $desc"; return }
 
     subtest $desc => {

--- a/t/test-util/01-is-eqv.t
+++ b/t/test-util/01-is-eqv.t
@@ -1,19 +1,22 @@
-use lib <t/spec/packages/ packages/>;
+use v6;
+use lib $?FILE.IO.parent(3).add("packages");
 use Test;
 use Test::Util;
 
 plan 10;
 
 sub is-eqv-fails ($code, $desc) {
-    is_run ｢
-        use lib <t/spec/packages/ packages/>;
+    my $package-lib-prefix = $?FILE.IO.parent(3).add('packages').absolute;
+
+    is_run ~ "use lib <{$package-lib-prefix}>;\n" ~ ｢
         use Test;
         use Test::Util;
       ｣ ~ $code,
       {
         :out{so .contains: all 'not ok', 'meows'},
         :err{.contains: 'Failed test'}
-      }, $desc;
+      },
+      $desc;
 }
 
 is-eqv Seq,           Seq,           'Seq:U, Seq:U';


### PR DESCRIPTION
Absolutify lib paths and file paths using $?FILE.IO.parent(...),
since a test can know the file layout of its own repo but not the
cwd the user is invoking a test from.

This allows you to install perl6, clone the roast anywhere you
wish, and then run the spectest with:
prove -v -e 'perl6' path/to/roast/*.t

fudging still needs to be done:
perl fudgeall rakudo.moar **/*.t > test-list-spaces.txt
perl -p -e 's/\s+/\n/g' test-list-spaces.txt > test-list.txt
prove --ignore-exit -r -j4 -e 'perl6' - < test-list.txt

This doesn't handle the spectest.data list since it does not exist
in this repo. The important step here is simply getting out of
the rakudo repo, which makes parallel build system stuff possible.