### PR TITLE
Test Issue 1204 (Strip slip in quotewords)

### DIFF
--- a/S02-literals/allomorphic.t
+++ b/S02-literals/allomorphic.t
@@ -7,7 +7,7 @@ use Test::Util;
 
 # L<S02/Allomorphic value semantics>
 
-plan 107;
+plan 110;
 
 ## Sanity tests (if your compiler fails these, there's not much hope for the
 ## rest of the test)
@@ -334,4 +334,11 @@ subtest '.ACCEPTS' => {
         is-deeply $allo.ACCEPTS($thing), False,
             "{$allo.perl}.ACCEPTS({$thing.perl})"
     }
+}
+
+# [Issue 1204](https://github.com/rakudo/rakudo/issues/1204)
+{
+    cmp-ok val(<1 2 3>     ), '!~~', Slip, 'val List candidate returns List by default (1)';
+    isa-ok val(<1 2 3>     ), List, 'val List candidate returns List by default (2)';
+    isa-ok val(<1 2 3>.Slip), Slip, 'val List candidate preserves slip-ness if passed Slip';
 }

--- a/S02-literals/quoting-unicode.t
+++ b/S02-literals/quoting-unicode.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 88;
+plan 101;
 
 #L<S02/Literals>
 # TODO:
@@ -131,4 +131,41 @@ plan 88;
 	"Can't mix curly quote with ASCII quote";
     is ‘"Beth's Cafe"’, ’"Beth's Cafe"‘, "curly ’‘ quotes are accepted and not confused with ASCII quotes";
 }
+
+# [Issue 1204](https://github.com/rakudo/rakudo/issues/1204)
+#
+# This block does not exhaustively test arrays in « »
+# That is still a todo item, (see todo block at top of file)
+{
+    my $x = '5 6';
+    my @a = 'a', 'b';
+
+    cmp-ok    « $x », '!~~', Slip,  'Single interpolated Scalar does not return as Slip';
+    is-deeply « $x », ( <5>, <6> ), 'Single interpolated Scalar correct result';
+
+    cmp-ok    « @a[] », '!~~', Slip, 'Single interpolated Array does not return as Slip';
+    is-deeply « @a[] », ('a', 'b'),  'Single interpolated Array correct result';
+
+    cmp-ok    « {21*2} », '!~~', Slip, 'Single interpolated block does not return as Slip';
+    is-deeply « {21*2} », (<42>),      'Single interpolated block correct result';
+
+    is « "$x" », '5 6', 'Single interpolated value in dbl quotes, preserves String';
+
+    is-deeply « z$x », ( 'z', <5>, <6> ),
+        'Literal directly precedes interpolated Scalar, no nested List produced';
+
+    is-deeply « z@a[] », ( 'z', 'a', 'b' ),
+        'Literal directly precedes interpolated Array, no nested List produced';
+    is-deeply « @a[]z », ( 'a', 'b', 'z' ),
+        'Literal directly follows interpolated Array, no nested List produced';
+
+    is-deeply « z{21*2} », ( 'z', <42> ),
+        'Literal directly precedes interpolated block, no nested List produced';
+    is-deeply « {21*2}z », ( <42>, 'z' ),
+        'Literal directly follows interpolated block, no nested List produced';
+
+    is-deeply « y{21*2}$x@a[]z », ( 'y', <42>, <5>, <6>, 'a', 'b', 'z' ),
+        'Literals directly bookend multiple interpolated, no nested Lists';
+}
+
 # vim: ft=perl6

--- a/S02-literals/quoting.t
+++ b/S02-literals/quoting.t
@@ -3,7 +3,7 @@ use lib <t/spec/packages>;
 use lib <packages>;
 use Test;
 use Test::Util;
-plan 191;
+plan 210;
 
 my $foo = "FOO";
 my $bar = "BAR";
@@ -661,6 +661,45 @@ ok qq:to/EOF/ ~~ /\t/, '\t in heredoc does not turn into spaces';
     diag 'The following test might STDERR about unfound command';
     lives-ok { qx/the-cake-is-a-lie-badfsadsadsadasdsadasdsadsadasdsadas/ },
       'qx// with a non-existent command does not die';
+}
+
+# [Issue 1204](https://github.com/rakudo/rakudo/issues/1204)
+{
+    my $x = '5 6';
+    my @a = 'a', 'b';
+
+    cmp-ok    qqww{   $x }, '!~~', Slip,  'Single interpolated Scalar does not return as Slip (qqww)';
+    is-deeply qqww:v{ $x }, ( <5>, <6> ), 'Single interpolated Scalar correct result (qqww:v)';
+    cmp-ok    << $x >>, '!~~', Slip,  'Single interpolated Scalar does not return as Slip (<< >>)';
+    is-deeply << $x >>, ( <5>, <6> ), 'Single interpolated Scalar correct result (<< >>)';
+
+    cmp-ok    qqww{ @a[] }, '!~~', Slip, 'Single interpolated Array does not return as Slip (qqww)';
+    is-deeply qqww{ @a[] }, ('a', 'b'),  'Single interpolated Array correct result (qqww)';
+    cmp-ok    << @a[] >>, '!~~', Slip, 'Single interpolated Array does not return as Slip (<< >>)';
+    is-deeply << @a[] >>, ('a', 'b'),  'Single interpolated Array correct result (<< >>)';
+
+    cmp-ok    qqww{ {21*2} }, '!~~', Slip, 'Single interpolated block does not return as Slip (qqww)';
+    is-deeply qqww:v[ {21*2} ], (<42>),    'Single interpolated block correct result (qqww:v)';
+    cmp-ok    << {21*2} >>, '!~~', Slip,   'Single interpolated block does not return as Slip (<< >>)';
+    is-deeply << {21*2} >>, (<42>),        'Single interpolated block correct result (<< >>)';
+
+    is << "$x" >>, '5 6', 'Single interpolated value in dbl quotes, preserves String';
+
+    is-deeply << z$x >>, ( 'z', <5>, <6> ),
+        'Literal directly precedes interpolated Scalar, no nested List produced';
+
+    is-deeply << z@a[] >>, ( 'z', 'a', 'b' ),
+        'Literal directly precedes interpolated Array, no nested List produced';
+    is-deeply << @a[]z >>, ( 'a', 'b', 'z' ),
+        'Literal directly follows interpolated Array, no nested List produced';
+
+    is-deeply << z{21*2} >>, ( 'z', <42> ),
+        'Literal directly precedes interpolated block, no nested List produced';
+    is-deeply << {21*2}z >>, ( <42>, 'z' ),
+        'Literal directly follows interpolated block, no nested List produced';
+
+    is-deeply << y{21*2}$x@a[]z >>, ( 'y', <42>, <5>, <6>, 'a', 'b', 'z' ),
+        'Literals directly bookend multiple interpolated, no nested Lists';
 }
 
 # vim: ft=perl6


### PR DESCRIPTION
This tests for bugs exhibited in
[Issue 1204](https://github.com/rakudo/rakudo/issues/1204).

Corresponds with development in Rakudo:
    [Commit ad684de383bb0c0ff051d7b0901583a9b5c2e398](https://github.com/rakudo/rakudo/commit/ad684de383bb0c0ff051d7b0901583a9b5c2e398)
    [PR 1350](https://github.com/rakudo/rakudo/pull/1350)

This does not provide cover every variation of the quoting syntax, but
hopefully provides sufficient coverage.