### PR TITLE
Rakudo Issue 1261: Test that there no binding to immutable List/Map

### DIFF
--- a/S02-types/list.t
+++ b/S02-types/list.t
@@ -3,7 +3,7 @@ use lib <t/spec/packages/>;
 use Test;
 use Test::Util;
 
-plan 76;
+plan 78;
 
 isa-ok (5, 7, 8), List, '(5, 7, 8) is List';
 is +(5, 7, 8), 3, 'prefix:<+> on a List';
@@ -189,6 +189,15 @@ subtest 'List.new does not create unwanted containers' => {
         'no containers were created';
     lives-ok { $l[2] = 42 }, 'passed containers get preserved';
     is-deeply $l[2], 42, 'value assigneed to passed container is right';
+}
+
+# [Github Issue 1261](https://github.com/rakudo/rakudo/issues/1261)
+{
+    my $s = 21;
+    my $l = ( 1, 2, $s );
+
+    throws-like { $l[0] := 10 }, X::Bind, 'Cannot bind at pos of immutable List';
+    throws-like { $l[2] := 10 }, X::Bind, 'Cannot bind at pos of immutable List, Scalar at pos';
 }
 
 # vim: ft=perl6

--- a/S32-hash/map.t
+++ b/S32-hash/map.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 11;
+plan 13;
 
 {
     my %hash = :foo, :42bar;
@@ -46,6 +46,15 @@ subtest 'Map.gist shows only first 100 els' => {
         with (1..204).list;
     is-deeply Map.new($_).gist, make-gist($_, '...'), '1000 els'
         with (1..2000).list;
+}
+
+# [Github Issue 1261](https://github.com/rakudo/rakudo/issues/1261)
+{
+    my $s  = 21;
+    my $m := Map.new: (foo => 42, bar => $s);
+
+    throws-like { $m<foo> := 10 }, X::Bind, 'Cannot bind at key of immutable Map';
+    throws-like { $m<bar> := 10 }, X::Bind, 'Cannot bind at key of immutable Map, Scalar value';
 }
 
 # vim: ft=perl6


### PR DESCRIPTION
Also add tests involving binding at a key or position where a Scalar
container resides. Binding should not be allowed in those instances
either.

Addresses
[Rakudo Issue 1261](https://github.com/rakudo/rakudo/issues/1261)