### PR TITLE
Rakudo Issue 1304: Unfudge now passing negated chain tests on JVM

### DIFF
--- a/S03-operators/relational.t
+++ b/S03-operators/relational.t
@@ -150,7 +150,6 @@ is(0 == 0 ~~ (* == 0), 0 ~~ 0 && 0 ~~ (* == 0), "chained smartmatch == ~~ with c
 
 is  1 !before 2 !before 3,  1 !before 2 && 2 !before 3,  'chained !before';
 is  1 !after 2 !after 2,  1 !after 2 && 2 !after 2,  'chained !after';
-#?rakudo.jvm 2 todo 'Chainable ops silently fail to be chained when negated R#1304'
 is  3 !> 3 !> 1,  3 !> 3 && 3 !> 1,  'chained !>';
 is  3 !< 3 !< 2,  3 !< 3 && 3 !< 2,  'chained !<';
 


### PR DESCRIPTION
See <https://github.com/rakudo/rakudo/issues/1304>.

Depends on <https://github.com/perl6/nqp/pull/402> and <https://github.com/rakudo/rakudo/pull/1448>