### PR TITLE
S16 io eof wsl script fudge

### DIFF
--- a/packages/Test/Util.pm
+++ b/packages/Test/Util.pm
@@ -343,6 +343,10 @@ sub fails-like (
 sub run-with-tty (
     $code, $desc, :$in = '', :$status = 0, :$out = '', :$err = ''
 ) is export {
+    if $*DISTRO.name eq 'ubuntu' and $*KERNEL.release ~~ /:i Microsoft/ {
+        skip "Current WSL does not support script command for test: roast issue #395";
+        return;
+    }
     state $path = make-temp-file.absolute;
     # on MacOS, `script` doesn't take the command via `c` arg
     state $script = shell(:!out, :!err, 'script -t/dev/null -qc "" /dev/null')

--- a/packages/Test/Util.pm
+++ b/packages/Test/Util.pm
@@ -344,7 +344,7 @@ sub run-with-tty (
     $code, $desc, :$in = '', :$status = 0, :$out = '', :$err = ''
 ) is export {
     if $*DISTRO.name eq 'ubuntu' and $*KERNEL.release ~~ /:i Microsoft/ {
-        skip "Current WSL does not support script command for test: roast issue #395";
+        skip 'WSL as of Mar 2018 did not support `script` command for test: roast issue #395';
         return;
     }
     state $path = make-temp-file.absolute;


### PR DESCRIPTION
See issue #395.  Since we change Test::Util run-with-tty we also effect S32-io/out-buffering.t as well as S16-io/eof.t.  On WSL/ubuntu 16 out-buffering.t also breaks the terminal but it ran OK on WSL ubuntu 14 since, unlike eof.t, the script process did not read from stdin.  Having the out-buffering.t test run on ubuntu 14 does not seem FTM worth a more complicated patch.