### PR TITLE
Fix attribute mutator tests and add comment discouraging use

### DIFF
--- a/S12-attributes/mutators.t
+++ b/S12-attributes/mutators.t
@@ -10,42 +10,64 @@ use v6;
 
 use Test;
 
-plan 10;
+plan 14;
 
-our $count = 0;
+our ($count-s, $count-m) = (0, 0);
 
 class MagicVal {
     has Int $.constant;
-    has Int $.varies = 0;
 
-    method varies is rw {
-        $count++;
+    # if you declare varies-m after varies-s you get
+    # P6opaque: no such attribute error
+    has Int $.varies-m = 0; # mutator attempting to use methods
+    method varies-m is rw {
+        $count-m++;
+
+        return Proxy.new(
+            FETCH => method ()     { $!varies-m  },
+            STORE => method ($new) { $!varies-m = $new + 1 },
+        );
+    }
+
+    has Int $.varies-s = 0; # mutator using subs
+    method varies-s is rw {
+        $count-s++;
+
         return Proxy.new(
             # note that FETCH and STORE cannot go through the accessors
             # of $.varies again, because that would lead to infinite
             # recursion. Use the actual attribute here instead
-            FETCH => sub ($ --> Int) { $!varies },
-            STORE => sub ($, Int $new --> Int) { $!varies = $new + 1 }
+            FETCH => sub ($ --> Int) { $!varies-s },
+            STORE => sub ($, Int $new --> Int) { $!varies-s = $new + 1 }
         );
     }
+
 }
 
-my $mv = MagicVal.new(:constant(6), :varies(6));
+my $mv = MagicVal.new(:constant(6), :varies-s(6), :varies-m(6));
 
-is($mv.constant, 6, "normal attribute");
 is($mv.constant, 6, "normal attribute");
 dies-ok { $mv.constant = 7 }, "can't change a non-rw attribute";
 is($mv.constant, 6, "attribute didn't change value");
+ok($count-s == 0 && $count-m == 0, "mutators not called yet");
 
-is($count, 0, "mutator not called yet");
+is($mv.varies-s, 6, "mutator called during object construction");
+is($count-s, 1, "accessor by sub was called ");
+
+$count-s = 0;
+$mv.varies-s = 13;
+is($count-s, 1, "mutator by sub was called");
+is($mv.varies-s, 14, "attribute with overridden mutator by sub");
+is($count-s, 2, "accessor and mutator by sub were called");
+
 #?rakudo skip 'RT #126198'
 {
-    is($mv.varies, 6, "mutator called during object construction");
-    is($count, 1, "accessor was called");
+    is($mv.varies-m, 6, "mutator by method called during object construction");
+    is($count-m, 1, "accessor by method was called");
 
-    $count = 0;
-    $mv.varies = 13;
-    is($count, 1, "mutator was called");
-    is($mv.varies, 14, "attribute with overridden mutator");
-    is($count, 2, "accessor and mutator were called");
+    $count-m = 0;
+    $mv.varies-m = 13;
+    is($count-m, 1, "mutator by method was called");
+    is($mv.varies-m, 14, "attribute with overridden mutator by method");
+    is($count-m, 2, "accessor and mutator by method were called");
 }

--- a/S12-attributes/mutators.t
+++ b/S12-attributes/mutators.t
@@ -3,6 +3,11 @@ use v6;
 # this tests that you can define mutators, that do more interesting
 # things than merely assigning the value!
 
+#
+# use of heavy attribute mutators is discouraged as poor OO design
+# see https://6guts.wordpress.com/2016/11/25/perl-6-is-biased-towards-mutators-being-really-simple-thats-a-good-thing/
+#
+
 use Test;
 
 plan 10;
@@ -19,8 +24,8 @@ class MagicVal {
             # note that FETCH and STORE cannot go through the accessors
             # of $.varies again, because that would lead to infinite
             # recursion. Use the actual attribute here instead
-            FETCH => method ()     { $!varies  },
-            STORE => method ($new) { $!varies = $new + 1 },
+            FETCH => sub ($ --> Int) { $!varies },
+            STORE => sub ($, Int $new --> Int) { $!varies = $new + 1 }
         );
     }
 }


### PR DESCRIPTION
There seems to be more than one school of thought about using attribute mutators.  There is the @jnthn school of thought discouraging their use as mentioned in the header comment referring to the [6guts blog post](https://6guts.wordpress.com/2016/11/25/perl-6-is-biased-towards-mutators-being-really-simple-thats-a-good-thing/) and the @zoffixznet school of thought which seems more tolerant based on his [recent advent post](https://perl6advent.wordpress.com/2017/12/02/perl-6-sigils-variables-and-containers/) (the end of the section of the post on "Customizing").  I don't know which school of thought wins but believe we can do better than leaving the test broken.