### PR TITLE
Update class-and-instance.t - tests for class and instance only methods

### DIFF
--- a/S12-methods/class-and-instance.t
+++ b/S12-methods/class-and-instance.t
@@ -2,10 +2,19 @@ use v6;
 
 use Test;
 
-plan 8;
+plan 12;
 
 class Foo {
+    has $.foo-bonus;
+
     method bar (Foo $class: $arg) { return 100 + $arg }   #OK not used
+
+    # xor methods call either class or instance not both
+    multi method bar-Foo-xor (::?CLASS:U: $arg) { return 10 + $arg }
+    multi method bar-Foo-xor (::?CLASS:D: $arg) { return 20 + $arg }
+    method bar-Foo-named-instance (Foo:D $inst: $arg) {
+        return 20 + $inst.foo-bonus + $arg
+    }
 }
 
 {
@@ -24,6 +33,16 @@ class Foo {
     }, '... class|instance methods work for instance';
     is($val, 142, '... basic instance method access worked');
 }
+
+is(Foo.bar-Foo-xor(42), 52, 'multi method for class not instance');
+is(Foo.new.bar-Foo-xor(42), 62, 'multi method for instance not class');
+is( Foo.new(:25foo-bonus).bar-Foo-named-instance(42), 87,
+    'instance only method named invocant'
+);
+throws-like(
+    { Foo.bar-Foo-named-instance(42) }, X::Parameter::InvalidConcreteness,
+    'correctly refused class invocant for instance only method'
+);
 
 class Act {
     my method rules() { 'the world' }


### PR DESCRIPTION
Tests for class and instance only methods selected by invocant concreteness (eg ::?CLASS:[U|D]:).
GH roast issue #217.