### PR TITLE
Test installation with proper Distribution usage

### DIFF
--- a/S11-repository/curli-install.t
+++ b/S11-repository/curli-install.t
@@ -20,7 +20,7 @@ $repo-path.IO.mkdir;
 }
 
 my $prefix   = $repo-path.IO.parent;
-my %provides = Foo => $prefix.child('Foo.pm').relative($prefix);
+my %provides = Foo => 'Foo.pm';
 my $dist              = Distribution::Hash.new({ :name<Foo>, :api<1>, :ver(v1.2.3), :%provides }, :$prefix);
 my $non-matching-dist = Distribution::Hash.new({ :name<Foo>, :api<2>, :ver(v2.3.4), :%provides }, :$prefix);
 


### PR DESCRIPTION
The intent of this test is installing a Distribution, and the fact
it used a class called Distribution to do it should be irrelevant.
This instead installs something that *does* Distribution.

Changed s/$path/$repo-path/ for clarity since $path is used as a
variable name elsewhere.