### PR TITLE
Add tests for #2143, Distribution::Resource.^mro

### DIFF
--- a/MISC/bug-coverage.t
+++ b/MISC/bug-coverage.t
@@ -6,7 +6,22 @@ use Test::Util;
 # This file is for random bugs that don't really fit well in other places.
 # Feel free to move the tests to more appropriate places.
 
-plan 11;
+plan 12;
+
+#https://github.com/rakudo/rakudo/issues/2143
+subtest 'Distribution::Resources works with .gist/.perl/.^mro/.WHAT' => {
+	plan 4;
+	Distribution::Resource.gist; pass '.gist';
+	Distribution::Resource.perl; pass '.perl';
+	Distribution::Resource.^mro; pass '.^mro';
+	Distribution::Resource.new(:repo("repo"), 
+				:repo-name("repo-name"), 
+				:dist-id("dist"), 
+				:key("key")).WHAT; 
+	pass '.WHAT on instances of Distribution::Resource';
+
+
+}
 
 subtest '.count-only/.bool-only for iterated content' => {
     plan 12;


### PR DESCRIPTION
This pull request adds tests which I believe cover Rakudo's [#2143](https://github.com/rakudo/rakudo/issues/2143), which the possible exception of `Distribution::Resource.Str`.

The added tests cover `Distribution::Resource.^mro`, `Distribution::Resource.perl`, `Distribution::Resource.gist`, and `.WHAT` on an instance object. However, that instance is created with `Distribution::Resource.new` (which I copied the form from [here](https://github.com/rakudo/rakudo/blob/d77a51de230516f8cb0139df08c93590e1fb5356/src/core/Distribution.pm6#L274)) instead from `%?RESOURCES`, and thus might not being completely natural. This test does not check `Distribution::Resource.Str` because I do not know if that should work or not.

I am quite willing to move my tests to a better file, or add `Distribution::Resource.Str` to the checked tests if someone who knows more can give input.