### PR TITLE
Check .:< ... > for prefix operators on int literals

### DIFF
--- a/S02-literals/numeric.t
+++ b/S02-literals/numeric.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 67;
+plan 68;
 
 isa-ok 1, Int, '1 produces a Int';
 does-ok 1, Numeric, '1 does Numeric';
@@ -121,4 +121,11 @@ ok 0e999999999999999 == 0, '0e999999999999 equals zero';
     is ∞, Inf, "yeah, we do that too...";
 }
 
+
+# https://github.com/rakudo/rakudo/issues/2094
+subtest '#2094 prefix as post fix works on number literals' => {
+   plan 2;
+   ok 42.:<-> == -42, 'use negation as postfix';
+   ok 42.:<~> === "42", 'use ~ as postfix';
+}
 # vim: ft=perl6 sw=4 ts=4 expandtab

--- a/S02-literals/numeric.t
+++ b/S02-literals/numeric.t
@@ -124,8 +124,12 @@ ok 0e999999999999999 == 0, '0e999999999999 equals zero';
 
 # https://github.com/rakudo/rakudo/issues/2094
 subtest '#2094 prefix as post fix works on number literals' => {
-   plan 2;
-   ok 42.:<-> == -42, 'use negation as postfix';
-   ok 42.:<~> === "42", 'use ~ as postfix';
+   plan 6;
+   eval-lives-ok q{42.:<-> == -42}, 'use negation as postfix';
+   eval-lives-ok q{42.:<~> === "42"}, 'use ~ as postfix';
+   eval-lives-ok q{42.:«~» === "42"}, 'use « » to wrap the prefix';
+   eval-lives-ok q{42.:<<~>> === "42"}, 'use << >> to wrap the prefix';
+   eval-lives-ok q{42.:["~"] === "42"}, 'use [" "] to wrap the prefix';
+   eval-lives-ok q{42.:<<'~'>> === "42"}, "use <<' '>> to wrap the prefix";
 }
 # vim: ft=perl6 sw=4 ts=4 expandtab


### PR DESCRIPTION
This commit goes with issue [Rakudo/#2094](https://github.com/rakudo/rakudo/issues/2094) on GitHub. In the current release of Rakudo `42.:<->` errors from an overaggressive check to prevent integers from ending with fullstops. This commit checks to confirm that `42.:<->` does equal `-42`. 

The corresponding pull request for Rakudo is [#2225](https://github.com/rakudo/rakudo/pull/2225).