### PR TITLE
Cover more iterator opt tests

### DIFF
--- a/MISC/bug-coverage.t
+++ b/MISC/bug-coverage.t
@@ -9,7 +9,7 @@ use Test::Util;
 plan 11;
 
 subtest '.count-only/.bool-only for iterated content' => {
-    plan 12;
+    plan 18;
 
     test-iter-opt  <a b c>.iterator,         3, 'List.iterator';
     test-iter-opt  <a b c>.reverse.iterator, 3, 'List.reverse.iterator';
@@ -25,6 +25,13 @@ subtest '.count-only/.bool-only for iterated content' => {
     test-iter-opt :42foo.kv.iterator,  2, 'Pair.kv.iterator';
     test-iter-opt %(:42foo, :70bar).kv.iterator, 4, 'Hash.kv.iterator';
     test-iter-opt %(:42foo, :70bar, :2meow).keys.iterator, 3, 'Hash.keys.iterator';
+
+    test-iter-opt "a\nb\nc".lines.iterator, 3, 'Str.lines.iterator';
+    test-iter-opt (my @a[5]).iterator,      5, '1 dim shaped array';
+    test-iter-opt 'abc'.comb.iterator,      3, 'Str.comb';
+    test-iter-opt 'abc'.comb(/./).iterator, 3, 'Str.comb(Regex)';
+    test-iter-opt 'abc'.comb(2).iterator,   2, 'Str.comb(Int)';
+    test-iter-opt 'aba'.comb('a').iterator, 2, 'Str.comb(Str)';
 }
 
 # https://github.com/rakudo/rakudo/issues/1407


### PR DESCRIPTION
Covers bugs fixed by
https://github.com/rakudo/rakudo/commit/64ddacab8f
https://github.com/rakudo/rakudo/commit/9738dfbf21
https://github.com/rakudo/rakudo/commit/d1e80dfe28
https://github.com/rakudo/rakudo/commit/9ff1736761

Merge was blocked by R#2075 https://github.com/rakudo/rakudo/issues/2075
as some of the opt methods return incorrect values after IterationEnd