### PR TITLE
Fix macos watch-path

### DIFF
--- a/S17-supply/watch-path.t
+++ b/S17-supply/watch-path.t
@@ -158,7 +158,7 @@ sub macosx (:$io-path) {
         ok $handle.close, 'did the file close ok';
 
         sleep $forawhile;
-        is +@seen, 1, 'did we get an event for closing the file';
+        is +@seen, 2, 'did we get an event for closing the file';
 
         $handle = open( $filename, :a );
         isa-ok $handle, IO::Handle, 'did we get a handle again?';
@@ -180,7 +180,7 @@ sub macosx (:$io-path) {
         ok $handle.close, 'did closing the file again work';
 
         sleep $forawhile;
-        is +@seen, 3, 'did we get an event for closing the file again';
+        is +@seen, 4, 'did we get an event for closing the file again';
 
         $check-event = -> \change {
             # TODO XXX: Do we want/have to use "FileChanged" for this?

--- a/S17-supply/watch-path.t
+++ b/S17-supply/watch-path.t
@@ -4,7 +4,7 @@ use Test;
 
 plan 4;
 
-my $forawhile = 1;
+my $forawhile = 4;
 my $filename = "watch-path_checker";
 END { unlink $filename if $filename }  # make sure we cleanup
 
@@ -118,6 +118,11 @@ sub macosx (:$io-path) {
         # When watching a file, it must exist before we watch it
         my $handle = open( $filename, :w );
         isa-ok $handle, IO::Handle, 'did we get a handle?';
+
+        # We need to wait long enough for the notification caused by creating
+        # the file above to be lost.  Otherwise it will arrive after the
+        # Supply is created and confuse the count.
+        sleep $forawhile;
 
         my $s = (
             $io-path ?? $filename.IO.watch !! IO::Notification.watch-path: $filename

--- a/S17-supply/watch-path.t
+++ b/S17-supply/watch-path.t
@@ -28,7 +28,7 @@ given $*DISTRO.name {
 
 #====  specific tests from here
 sub macosx (:$io-path) {
-    plan 64;
+    plan 55;
     # check watching directories
     {
         my $base-path = '.';


### PR DESCRIPTION
This PR addresses a few issues with the watch-path tests on macOS.  Unfortunately it makes the test take a little over 2 minutes to run [and it does still occasionally generate incorrect failures] but this is the only combo that regularly passes on my machine.

In the long term it would be better to find a way of waiting up to a specified timeout for each expected event, rather than just counting hits and having to find a timeout that's "mostly ok" without spending too much time waiting.

I'm uncertain about the specified behaviour in https://github.com/perl6/roast/commit/dcf672cfb2d3cb4fd81f3c028784fd24f82bb2b4.  It seems that we don't get an notification for opening an existing file for append.  That seems sensible to me, but the wording on the test doesn't make it clear whether or not that's really the expected bevahiour.