### PR TITLE
Fix issue with macOS /bin/sh and weird source names

### DIFF
--- a/S32-str/utf8-c8.t
+++ b/S32-str/utf8-c8.t
@@ -90,8 +90,10 @@ else {
         is $proc.out.get, 'lived', 'Can run Perl 6 with non-UTF-8 environment';
     }
     {
-        my $cmd = Q{echo 'say(42)' > $'L\xe9on' && } ~ $*EXECUTABLE ~ Q{ $'L\xe9on' && rm $'L\xe9on'};
-        my $proc = shell $cmd, :out;
+        my $filename = "L\xe9on";
+        spurt $filename, 'say(42)';
+        LEAVE { try unlink $filename }
+        my $proc = run $*EXECUTABLE, $filename, :out;
         is $proc.out.get, '42', 'Can run Perl 6 sourcefile with non-UTF-8 name';
     }
 }


### PR DESCRIPTION
This test was causing errors on macOS with the following message:

/bin/sh: Lon: Illegal byte sequence

/bin/sh on macOS 10.14.1 is Bash 3.2.57.  This patch takes the shell
out of the equation by using `run` instead of `shell`.