### PR TITLE
add tests for require:file<> containing classes

### DIFF
--- a/S11-modules/require.t
+++ b/S11-modules/require.t
@@ -15,7 +15,7 @@ use lib $?FILE.IO.parent(2).add("packages/Cool/lib");
 
 use MONKEY-SEE-NO-EVAL;
 
-plan 34;
+plan 38;
 
 # RT #126100
 {
@@ -64,17 +64,15 @@ throws-like { require InnerModule:file($name) <quux> },
     X::Import::MissingSymbols,
 '&-less import of sub does not produce `Null PMC access` error';
 
-my $class-name = $?FILE.IO.parent(2).add('packages/S11-modules/lib/InnerClass.pm6').absolute;
 {
-    require TestStub:file($class-name);
+    my $class-path = $?FILE.IO.parent(2).add('packages/S11-modules/lib/InnerClass.pm6').absolute;
+    require TestStub:file($class-path);
     my @keys = TestStub::.keys;
     is @keys.grep('InnerClass').elems, 1, 'can load InnerClass.pm6 class into specified stub';
-    ok TestStub::<InnerClass>.^can('test1'), 'TestStub::<InnerClass>.test1 is available';
-    ok try { TestStub::<InnerClass>.test1 } eq 'test1', 'TestStub::<InnerClass>.test1 is callable';
+    ok TestStub::<InnerClass>.test1 eq 'test1', 'TestStub::<InnerClass>.test1 is callable';
     
     is @keys.grep('InnerClassTwo').elems, 1, 'can load multiple classes from InnerClass.pm6 class into specified stub';
-    ok TestStub::<InnerClassTwo>.^can('test2'), 'TestStub::<InnerClass>.test1 is available';
-    ok try { TestStub::<InnerClassTwo>.test2 } eq 'test2', 'TestStub::<InnerClass>.test1 is callable';
+    ok TestStub::<InnerClassTwo>.test2 eq 'test2', 'TestStub::<InnerClass>.test1 is callable';
 }
 
 # no need to do that at compile time, since require() really is run time

--- a/S11-modules/require.t
+++ b/S11-modules/require.t
@@ -64,6 +64,19 @@ throws-like { require InnerModule:file($name) <quux> },
     X::Import::MissingSymbols,
 '&-less import of sub does not produce `Null PMC access` error';
 
+my $class-name = $?FILE.IO.parent(2).add('packages/S11-modules/lib/InnerClass.pm6').absolute;
+{
+    require TestStub:file($class-name);
+    my @keys = TestStub::.keys;
+    is @keys.grep('InnerClass').elems, 1, 'can load InnerClass.pm6 class into specified stub';
+    ok TestStub::<InnerClass>.^can('test1'), 'TestStub::<InnerClass>.test1 is available';
+    ok try { TestStub::<InnerClass>.test1 } eq 'test1', 'TestStub::<InnerClass>.test1 is callable';
+    
+    is @keys.grep('InnerClassTwo').elems, 1, 'can load multiple classes from InnerClass.pm6 class into specified stub';
+    ok TestStub::<InnerClassTwo>.^can('test2'), 'TestStub::<InnerClass>.test1 is available';
+    ok try { TestStub::<InnerClassTwo>.test2 } eq 'test2', 'TestStub::<InnerClass>.test1 is callable';
+}
+
 # no need to do that at compile time, since require() really is run time
 PROCESS::<$REPO> := CompUnit::Repository::FileSystem.new(:next-repo($*REPO),
     :prefix($?FILE.IO.parent(2).child('packages/Fancy/lib').relative));

--- a/packages/S11-modules/lib/InnerClass.pm6
+++ b/packages/S11-modules/lib/InnerClass.pm6
@@ -1,0 +1,11 @@
+class InnerClass {
+  method test1() {
+    'test1';
+  }
+}
+
+class InnerClassTwo {
+  method test2() {
+    'test2';
+  }
+}


### PR DESCRIPTION
I have a PR coming to `rakudo` branch that merges `require stub:file<>` class symbols into `stub`, right now they're just ignored.

This test is fixed by see:rakudo/rakudo#2789