### PR TITLE
Test for GH 2684 (questions)

### DIFF
--- a/S10-packages/precompilation.t
+++ b/S10-packages/precompilation.t
@@ -3,7 +3,7 @@ use Test;
 use lib $?FILE.IO.parent(2).add("packages/Test-Helpers");
 use Test::Util;
 
-plan 49;
+plan 51;
 
 my @*MODULES; # needed for calling CompUnit::Repository::need directly
 
@@ -287,5 +287,18 @@ with make-temp-dir() -> $dir {
         is_run 'use lib \qq[$dir.absolute().perl()]; use Simple131924; print buggy-str() eq “: \n\r\n\r”',
              {:out<True>, :err(''), :0status},
 	     'no funny business with precompiled string strands (\qq[$_])';
+    }
+}
+
+# GH 2684
+with make-temp-dir() -> $dir {
+    $dir.add('GH2684.pm6').spurt: ｢
+        my $x; BEGIN { $x = -> { "foo".subst(/o/, 'a', :g) } }; $x();
+    ｣;
+
+    for ^2 {
+        is_run 'use lib \qq[$dir.absolute().perl()]; use GH2684;',
+            {:out(''), :err(''), :0status},
+	    "Dyncomp lexical lookup plays well with BEGIN blocks ($_)";
     }
 }


### PR DESCRIPTION
There are a couple of things I am not really sure about in this test, can someone, please, answer the following?

1)Description of `make-tmp-dir` says that the end-user must clean up created files beforehand, see https://github.com/perl6/roast/issues/384 ticket. But the previous test in this file does not seem to do any cleanup, so I didn't add it too. Should both tests be fixed? Or maybe we have to do something with the ticket? If yes, how can I help? To change `rmdir` into `rm -rf` equivalent and run spectest seeing if anything broke?
2)It seems that this issue did not end up in a release... I tried the test on both 2018.12 and 2019.03 and it just passes... But ultimately I am not sure if it passes because the test is correct and the bug is fixed already(and on 2018.12 it was not yet introduced) or it is just a broken test. Possibly I can roll back to the commit before the fix, but what to do with two dependent repos, moarvm and nqp, just search their respective commits of that time?

Issue link -> https://github.com/rakudo/rakudo/issues/2684