### PR TITLE
Tests for Rakudo issue 3116

### DIFF
--- a/S11-modules/importing.t
+++ b/S11-modules/importing.t
@@ -4,7 +4,7 @@ use Test;
 use lib $?FILE.IO.parent(2).add("packages/AandB/lib");
 use lib $?FILE.IO.parent(2).add("packages/S11-modules/lib");
 
-plan 17;
+plan 18;
 
 # L<S11/"Compile-time Importation"/>
 
@@ -58,5 +58,8 @@ throws-like 'use Foo :NoSucTag;', X::Import::NoSuchTag,
                 :source-package<Foo>,
                 :tag<NoSucTag>,
              'die while trying to import a non-existent export tag';
+
+# GH rakudo/rakudo#3116
+eval-lives-ok q<use NoPrecompilation;>, "`use` of module with `no precompilation` inside EVAL";
 
 # vim: ft=perl6

--- a/S11-modules/versioning.t
+++ b/S11-modules/versioning.t
@@ -1,0 +1,28 @@
+use v6;
+use lib <t/packages>;
+use Test;
+use Test::Helpers;
+
+my $lib-path = $?FILE.IO.parent(2).add("packages/S11-modules/lib");
+
+plan 9;
+
+for <c d e.PREVIEW> -> $from-rev {
+    for <c d e> -> $mod-rev {
+        subtest "6.$mod-rev from 6.$from-rev", {
+            plan 8;
+            for (:core-revision($mod-rev), :perl-version("6.$mod-rev")) -> (:key($routine), :value($response)) {
+                for (:use(''), :require(" <\&$routine>")) -> (:key($statement), :value($starg)) {
+                    is-run 'use v6.' ~$from-rev ~ '; ' ~ $statement ~ ' Module_6' ~ $mod-rev ~ $starg ~ '; print ' ~ $routine,
+                        "$statement: $routine is $response",
+                        :compiler-args('-I', $lib-path),
+                        :out($response), :err(""), :exitcode(0);
+                    is-run 'use v6.' ~ $from-rev ~ '; print EVAL("' ~ $statement ~ ' Module_6' ~ $mod-rev ~ $starg ~ '; ' ~ $routine ~ '")',
+                        "$statement in EVAL: $routine is $response",
+                        :compiler-args('-I', $lib-path),
+                        :out($response), :exitcode(0);
+                }
+            }
+        }
+    }
+}

--- a/packages/S11-modules/lib/Module_6c.pm6
+++ b/packages/S11-modules/lib/Module_6c.pm6
@@ -1,0 +1,5 @@
+use v6.c;
+unit module Module_6c;
+
+sub core-revision is export { CORE-SETTING-REV }
+sub perl-version is export { BEGIN $*PERL.version }

--- a/packages/S11-modules/lib/Module_6d.pm6
+++ b/packages/S11-modules/lib/Module_6d.pm6
@@ -1,0 +1,6 @@
+use v6.d;
+
+unit module Module_6d;
+
+sub core-revision is export { CORE-SETTING-REV }
+sub perl-version is export { BEGIN $*PERL.version }

--- a/packages/S11-modules/lib/Module_6e.pm6
+++ b/packages/S11-modules/lib/Module_6e.pm6
@@ -1,0 +1,5 @@
+use v6.e.PREVIEW;
+unit module Module_6e;
+
+sub core-revision is export { CORE-SETTING-REV }
+sub perl-version is export { BEGIN $*PERL.version }

--- a/packages/S11-modules/lib/NoPrecompilation.pm6
+++ b/packages/S11-modules/lib/NoPrecompilation.pm6
@@ -1,0 +1,5 @@
+use v6;
+unit module NoPrecompilation;
+no precompilation;
+
+sub the-answer is export { 42 }


### PR DESCRIPTION
Test a few more scenarios of combinations of `use`/`require` with module and run-time code versions. Special focus on `EVAL`ed code.

Followup to rakudo/rakudo#3116 and rakudo/rakudo#3113