### PR TITLE
Add tests for CORE::v6<rev> pseudo-packages

### DIFF
--- a/packages/S02-names/lib/Pseudo6c.pm6
+++ b/packages/S02-names/lib/Pseudo6c.pm6
@@ -1,0 +1,6 @@
+use v6.c;
+
+# Will return a PseudoStash from 6.c
+sub pseudo-stash is export {
+    MY::
+}

--- a/packages/S02-names/lib/Pseudo6d.pm6
+++ b/packages/S02-names/lib/Pseudo6d.pm6
@@ -1,0 +1,6 @@
+use v6.d;
+
+# Will return a PseudoStash from 6.c because 6.d doesn't define it
+sub pseudo-stash is export {
+    MY::
+}

--- a/packages/S02-names/lib/Pseudo6e.pm6
+++ b/packages/S02-names/lib/Pseudo6e.pm6
@@ -1,0 +1,6 @@
+use v6.e.PREVIEW;
+
+# Will return a PseudoStash from 6.e
+sub pseudo-stash is export {
+    MY::
+}


### PR DESCRIPTION
Test for namespaces referring their respective COREs and for valid
multi-dispatching over symbols from different COREs.

- perl6/problem-solving#80
- rakudo/rakudo#3112