### PR TITLE
Test for 6.e grammar Grammar name

### DIFF
--- a/S05-grammar/namespace-6e.t
+++ b/S05-grammar/namespace-6e.t
@@ -1,0 +1,7 @@
+use v6.e.PREVIEW;
+use Test;
+
+plan 1;
+
+# GH rakudo/rakudo#3132
+eval-lives-ok q<grammar Grammar {  }>, "we can create grammar named Grammar";

--- a/spectest.data
+++ b/spectest.data
@@ -400,6 +400,7 @@ S05-grammar/example.t
 S05-grammar/inheritance.t
 S05-grammar/methods.t
 S05-grammar/namespace.t
+S05-grammar/namespace-6e.t
 S05-grammar/parse_and_parsefile-6c.t
 S05-grammar/parse_and_parsefile-6e.t
 S05-grammar/polymorphism.t


### PR DESCRIPTION
It must be possible to create grammars named `Grammar`

rakudo/rakudo#3132