### PR TITLE
Revert "Include path for subprocess"

### DIFF
--- a/packages/Test-Helpers/lib/Test/Util.pm6
+++ b/packages/Test-Helpers/lib/Test/Util.pm6
@@ -213,10 +213,6 @@ sub get_out( Str $code, Str $input?, :@args, :@compiler-args) is export {
 
         my $cmd = $*EXECUTABLE.absolute ~ ' ';
         $cmd ~= @compiler-args.join(' ') ~ ' ' if @compiler-args;
-        use nqp;
-        # Add -I from our runner command line.
-        my %cli-args = nqp::getcomp("perl6").cli-options;
-        $cmd ~= .map( '-I' ~ * ).join(' ') ~ ' ' with %cli-args<I>;
         $cmd ~= $fnbase ~ '.code'  if $code.defined;
         $cmd ~= " @actual_args.join(' ') < $fnbase.in > $fnbase.out 2> $fnbase.err";
         # diag("Command line: $cmd");


### PR DESCRIPTION
Reverts perl6/roast#572

As @ugexe suggested, some tests might imply full control over their libpath.