### PR TITLE
Add a test for rakudo/rakudo#3299 Proc::Async memory corruption bug.

### DIFF
--- a/S17-procasync/many-processes-no-close-stdin.t
+++ b/S17-procasync/many-processes-no-close-stdin.t
@@ -1,16 +1,20 @@
 use v6;
 use Test;
+use lib $?FILE.IO.parent(2).add("packages/Test-Helpers");
+use Test::Util;
 
 plan 1;
 
-my $prog   = $*DISTRO.is-win ?? 'cmd'   !! 'cat';
-my @target = $*DISTRO.is-win ?? «/c ""» !! '/dev/null';
+is_run ｢
+    my $prog   = $*DISTRO.is-win ?? 'cmd'   !! 'cat';
+    my @target = $*DISTRO.is-win ?? «/c ""» !! '/dev/null';
 
-for ^1000 {
-    my $proc = Proc::Async.new($prog, |@target, :w);
+    for ^1000 {
+        my $proc = Proc::Async.new($prog, |@target, :w);
 
-    my $promise = $proc.start;
-    await $promise;
-}
+        my $promise = $proc.start;
+        await $promise;
+    }
 
-pass 'made it to the end';
+    print 'pass'
+｣, {:out<pass>, :err(''), :0status}, 'made it to the end';

--- a/S17-procasync/no-runaway-file-limit.t
+++ b/S17-procasync/no-runaway-file-limit.t
@@ -1,17 +1,20 @@
 use v6;
 use Test;
+use lib $?FILE.IO.parent(2).add("packages/Test-Helpers");
+use Test::Util;
 
 plan 1;
 
 # RT #125616
-my $prog   = $*DISTRO.is-win ?? 'cmd'   !! 'cat';
-my @target = $*DISTRO.is-win ?? «/c ""» !! '/dev/null';
-for ^1000 {
-    my $proc = Proc::Async.new($prog, |@target, :w);
-    $proc.stdout.tap(-> $data {});
-    my $p = $proc.start;
-    $proc.close-stdin;
-    await $p;
-}
-
-pass 'made it to the end';
+is_run ｢
+    my $prog   = $*DISTRO.is-win ?? 'cmd'   !! 'cat';
+    my @target = $*DISTRO.is-win ?? «/c ""» !! '/dev/null';
+    for ^1000 {
+        my $proc = Proc::Async.new($prog, |@target, :w);
+        $proc.stdout.tap(-> $data {});
+        my $p = $proc.start;
+        $proc.close-stdin;
+        await $p;
+    }
+    print 'pass'
+｣, {:out<pass>, :err(''), :0status}, 'made it to the end';

--- a/S17-procasync/stress.t
+++ b/S17-procasync/stress.t
@@ -7,7 +7,7 @@ plan 24;
 
 # RT #125515
 {
-    constant $read-file = $?FILE.IO.parent(2).add("packages/README");
+    constant $read-file = $?FILE.IO.parent(2).add("packages").add("README");
     $read-file.IO.r or bail-out "Missing $read-file that is needed to run a test";
 
     my @got;

--- a/S17-procasync/stress.t
+++ b/S17-procasync/stress.t
@@ -94,20 +94,19 @@ else {
     skip 'need `perl` to run this test';
 }
 
-{
-  my $prog   = $*DISTRO.is-win ?? 'cmd'   !! 'cat';
-  my @target = $*DISTRO.is-win ?? «/c ""» !! '/dev/null';
+# https://github.com/rakudo/rakudo/issues/3299
+is_run ｢
+    my $prog   = $*DISTRO.is-win ?? 'cmd'   !! 'cat';
+    my @target = $*DISTRO.is-win ?? «/c ""» !! '/dev/null';
 
-  for ^1200 {
-    print "\r$_ ";
+    for ^1200 {
       my $proc = Proc::Async.new($prog, |@target);
       react {
           whenever $proc.start { done }
           whenever signal(SIGTERM) {}
           whenever Promise.in(5) {}
       }
-  }
+    }
 
-  say '';
-  pass 'made it to the end without memory corruption';
-}
+    print 'pass'
+｣, {:out<pass>, :err(''), :0status}, 'No memory corruption when starting many Proc::Async instances';


### PR DESCRIPTION
There are 1200 iterations of a loop to try to reproduce the memory corruption bug.
Without the fix, typically fails after 500-800 iterations.
With the fix, takes about 13 seconds on my machine for all 1200 iterations.