### PR TITLE
Test for export of long names

### DIFF
--- a/S11-modules/import-long.t
+++ b/S11-modules/import-long.t
@@ -3,13 +3,30 @@ use Test;
 use lib $?FILE.IO.parent(2).add("packages/S11-modules/lib");
 use MONKEY-SEE-NO-EVAL;
 
-plan 9;
+plan 23;
 
 eval-lives-ok q<use LongNames;>, "export with overlapping short names doesn't fail";
 
 for <Foo Bar> -> $l1 {
+    # Classes
+    my $sym = 'class';
     for <C1 C2> -> $l2 {
-        is EVAL("use LongNames; {$l1}::{$l2}.^name"), "LongNames::{$l1}::{$l2}", "{$l1}::{$l2} -- exported symbol name includes it's enclosing module";
-        eval-lives-ok "use LongNames; {$l1}::{$l2}.new", "{$l1}::{$l2} -- export symbol is a class we can use";
+        is EVAL("use LongNames; {$l1}::{$l2}.^name"), "LongNames::{$l1}::{$l2}", "{$l1}::{$l2} -- exported $sym name includes it's enclosing module";
+        eval-lives-ok "use LongNames; {$l1}::{$l2}.new", "{$l1}::{$l2} -- exported symbol is a class we can use";
     }
+
+    # Enums
+    $sym = "enum";
+#?rakudo 1 todo "enum full name must include it's enclosing package, as subset does"
+    is EVAL("use LongNames; {$l1}::Vals.^name"), "LongNames::{$l1}::Vals", "{$l1}::Vals -- exported $sym name is as declared";
+    for <Val1 Val2> -> $v {
+        ok EVAL("use LongNames; {$l1}::Vals.WHO<{$l1}{$v}>:exists"), "{$l1}::Vals -- exported enum contains value {$l1}{$v}";
+    }
+    nok EVAL("use LongNames; {$l1}::Vals.WHO<{$l1}NoVal>:exists"), "{$l1}::Vals -- exported enum doesn't contain value {$l1}NoVal";
+
+    # Subsets
+    $sym = "subset";
+    is EVAL("use LongNames; {$l1}::MyInt.^name"), "LongNames::{$l1}::MyInt", "{$l1}::MyInt -- exported $sym name is as declared";
+    eval-lives-ok "use LongNames; my {$l1}::MyInt \$v = 13", "{$l1}::MyInt subset accepts allowed value";
+    eval-dies-ok "use LongNames; my {$l1}::MyInt \$v = 7", "{$l1}::MyInt subset dies on bad value";
 }

--- a/S11-modules/import-long.t
+++ b/S11-modules/import-long.t
@@ -1,9 +1,15 @@
 use v6.d;
 use Test;
 use lib $?FILE.IO.parent(2).add("packages/S11-modules/lib");
+use MONKEY-SEE-NO-EVAL;
 
-plan 3;
+plan 9;
 
 eval-lives-ok q<use LongNames;>, "export with overlapping short names doesn't fail";
-is EVAL(q<use LongNames; Foo::C2.^name>), "LongNames::Foo::C2", "exported symbol name includes it's enclosing module";
-eval-lives-ok q<use LongNames; Foo::C1.new>, "export symbol is a class we can use";
+
+for <Foo Bar> -> $l1 {
+    for <C1 C2> -> $l2 {
+        is EVAL("use LongNames; {$l1}::{$l2}.^name"), "LongNames::{$l1}::{$l2}", "{$l1}::{$l2} -- exported symbol name includes it's enclosing module";
+        eval-lives-ok "use LongNames; {$l1}::{$l2}.new", "{$l1}::{$l2} -- export symbol is a class we can use";
+    }
+}

--- a/S11-modules/import-long.t
+++ b/S11-modules/import-long.t
@@ -1,0 +1,9 @@
+use v6.d;
+use Test;
+use lib $?FILE.IO.parent(2).add("packages/S11-modules/lib");
+
+plan 3;
+
+eval-lives-ok q<use LongNames;>, "export with overlapping short names doesn't fail";
+is EVAL(q<use LongNames; Foo::C2.^name>), "LongNames::Foo::C2", "exported symbol name includes it's enclosing module";
+eval-lives-ok q<use LongNames; Foo::C1.new>, "export symbol is a class we can use";

--- a/packages/S11-modules/lib/LongNames.rakumod
+++ b/packages/S11-modules/lib/LongNames.rakumod
@@ -5,3 +5,9 @@ class Foo::C1 is export { }
 class Foo::C2 is export { }
 class Bar::C1 is export { }
 class Bar::C2 is export { }
+
+enum Foo::Vals is export <FooVal1 FooVal2>;
+enum Bar::Vals is export <BarVal1 BarVal2>;
+
+subset Foo::MyInt of Int is export where * > 10;
+subset Bar::MyInt of Int is export where * > 10;

--- a/packages/S11-modules/lib/LongNames.rakumod
+++ b/packages/S11-modules/lib/LongNames.rakumod
@@ -1,0 +1,7 @@
+use v6;
+unit module LongNames;
+
+class Foo::C1 is export { }
+class Foo::C2 is export { }
+class Bar::C1 is export { }
+class Bar::C2 is export { }

--- a/spectest.data
+++ b/spectest.data
@@ -610,6 +610,7 @@ S11-compunit/compunit-repository.t
 S11-compunit/rt126904.t
 S11-modules/export.t
 S11-modules/importing.t
+S11-modules/import-long.t
 S11-modules/import-multi.t
 S11-modules/import-tag.t
 S11-modules/import.t


### PR DESCRIPTION
Test for symbols declared with long names are exported and imported correctly.

Covers perl6/problem-solving#142