### PR TITLE
channel elements not yet consumed in the supply should still be accessible

### DIFF
--- a/S17-channel/basic.t
+++ b/S17-channel/basic.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 27;
+plan 28;
 
 {
     my Channel $c .= new;
@@ -92,6 +92,16 @@ plan 27;
 
     pass("Both workers detected end-of-channel after a shared channel close");
     $timer.close;
+}
+
+{
+    my $c = Channel.new;
+    $c.send(1);
+    $c.send(2);
+
+    react whenever $c { done }
+
+    is $c.poll, 2, 'second value should still be in the channel';
 }
 
 { # coverage; 2016-09-26


### PR DESCRIPTION
This tests rakudo issue [2646](https://github.com/rakudo/rakudo/issues/2646).