### PR TITLE
RAKULIB and PERL6LIB problem

### DIFF
--- a/S11-modules/rakulib.t
+++ b/S11-modules/rakulib.t
@@ -11,9 +11,9 @@ plan 1;
 
 my $path-to-dist = $?FILE.IO.parent($level).add("packages/Example/lib").absolute;
 
-subtest 'PERL6LIB (deprecated?)' => {
+subtest 'RAKULIB' => {
     plan 1;
     my $env = %*ENV;
-    $env<PERL6LIB> = $path-to-dist;
+    $env<RAKULIB> = $path-to-dist;
     ok run($*EXECUTABLE.absolute, "-e", "use Example::A", :$env, :!err, :!out).so;
 }

--- a/spectest.data
+++ b/spectest.data
@@ -620,6 +620,9 @@ S11-modules/module-file.t
 S11-modules/need.t
 S11-modules/nested.t
 S11-modules/perl6lib.t
+S11-modules/perl6lib-debug.t
+S11-modules/rakulib.t
+S11-modules/rakulib-debug.t
 S11-modules/require.t
 S11-modules/runtime.t
 S11-repository/curli-install.t


### PR DESCRIPTION
The recent addition of RAKULIB to the master branch has somehow caused some problems with roast test files added or modified for RAKULIB and PERL6LIB.

See details of the problem with gist https://gist.github.com/tbrowder/21c84659996a32b836f9b711463e2a7c

I have not tried to return to the original test formats before the changes, but I will try them in another PR.