### PR TITLE
[JVM] Fudge some failing tests

### DIFF
--- a/MISC/bug-coverage-stress.t
+++ b/MISC/bug-coverage-stress.t
@@ -10,6 +10,7 @@ use Test::Util;
 plan 14;
 
 # https://github.com/Raku/old-issue-tracker/issues/6501
+#?rakudo.jvm todo 'Fails more often than it passes'
 doesn't-hang ｢
     my $fh = ｣ ~ make-temp-file.raku ~ ｢.open: :w;
     await ^20 .map: -> $t {

--- a/S06-signature/closure-parameters.t
+++ b/S06-signature/closure-parameters.t
@@ -29,6 +29,7 @@ plan 28;
     throws-like 'testit(&teststr)', Exception, 'code dies with invalid signature (1)';
 
     ok(test-but-dont-call(&testint), 'code runs with proper signature (1)');
+    #?rakudo.jvm todo 'Code does not die'
     throws-like 'test-but-dont-call(&teststr)', Exception, 'code dies with invalid signature (1)';
 }
 
@@ -40,6 +41,7 @@ plan 28;
     my Int  sub teststrint (Str $foo) {return 0}   #OK not used
 
     ok(testit(&testintbool), 'code runs with proper signature (2)');
+    #?rakudo.jvm todo 'Code does not die'
     throws-like 'testit(&testintint)', Exception, 'code dies with invalid signature (2)';
     throws-like 'testit(&teststrbool)', Exception, 'code dies with invalid signature (3)';
     throws-like 'testit(&teststrint)', Exception,  'code dies with invalid signature (4)';
@@ -52,17 +54,21 @@ plan 28;
     multi sub t1 (&code:(Mu, Mu)) { 'Two' };   #OK not used
 
     # Note that using &code:($,$) instead of &code:(Any, Any) makes this next test work
+    #?rakudo.jvm todo "expected: 'Two', got: 'Int'"
     is t1(-> $a, $b { }), 'Two',   #OK not used
        'Multi dispatch based on closure parameter syntax (1)';
     is t1(-> Int $a { }), 'Int',   #OK not used
        'Multi dispatch based on closure parameter syntax (2)';
+    #?rakudo.jvm todo "expected: 'Str', got: 'Int'"
     is t1(-> Str $a { }), 'Str',   #OK not used
        'Multi dispatch based on closure parameter syntax (3)';
 
     sub takes-str-returns-bool(Str $x --> Bool) { True }   #OK not used
+    #?rakudo.jvm todo "expected: 'Str --> Bool', got: 'Int'"
     is t1(&takes-str-returns-bool), 'Str --> Bool',
        'Multi dispatch based on closure parameter syntax (4)';
 
+    #?rakudo.jvm todo 'Code does not die'
     dies-ok { t1( -> { 3 }) },
        'Multi dispatch based on closure parameter syntax (5)';
 }
@@ -92,6 +98,7 @@ subtest 'can use signature unpacking with anonymous parameters' => {
     plan 2;
     is -> &:(Str), 42 {100}(-> Str $v { $v.uc }, 42), 100,
         'can call with right signature';
+    #?rakudo.jvm todo 'Code does not die'
     throws-like '-> &:(Int) {}({;})', X::TypeCheck::Binding::Parameter,
         'typcheck correctly fails with wrong arg';
 }

--- a/S12-construction/destruction.t
+++ b/S12-construction/destruction.t
@@ -32,25 +32,30 @@ ok( ! $in_destructor,    'destructor should not fire while object is active' );
 my $child = Child.new();
 $child = Nil;
 
-# no guaranteed timely destruction, so try to force some GC here
-await start {
-    loop
-    {
-        # Non-MoarVM backends currently warn for this method, so surpress that
-        quietly $*VM.request-garbage-collection;
+if $*VM.name eq 'jvm' {
+    skip-rest "Hangs on JVM backend";
+}
+else {
+    # no guaranteed timely destruction, so try to force some GC here
+    await start {
+        loop
+        {
+            # Non-MoarVM backends currently warn for this method, so surpress that
+            quietly $*VM.request-garbage-collection;
 
-        my $foo = Foo.new;
-        my $chld = Child.new unless +@destructor_order;
-        last if $in_destructor && @destructor_order;
-    }
-};
+            my $foo = Foo.new;
+            my $chld = Child.new unless +@destructor_order;
+            last if $in_destructor && @destructor_order;
+        }
+    };
 
-#?rakudo.jvm todo "doesn't work, yet"
-ok( $in_destructor, '... only when object goes away everywhere'                          );
-is( +@destructor_order % 2, 0, '... only a multiple of the available DESTROY submethods' );
-#?rakudo.jvm todo "expected: 'Child', got: (Any)"
-is(  @destructor_order[0], 'Child',  'Child DESTROY should fire first'                   );
-#?rakudo.jvm todo "expected: 'Parent', got: (Any)"
-is(  @destructor_order[1], 'Parent', '... then parent'                                   );
+    #?rakudo.jvm todo "doesn't work, yet"
+    ok( $in_destructor, '... only when object goes away everywhere'                          );
+    is( +@destructor_order % 2, 0, '... only a multiple of the available DESTROY submethods' );
+    #?rakudo.jvm todo "expected: 'Child', got: (Any)"
+    is(  @destructor_order[0], 'Child',  'Child DESTROY should fire first'                   );
+    #?rakudo.jvm todo "expected: 'Parent', got: (Any)"
+    is(  @destructor_order[1], 'Parent', '... then parent'                                   );
+}
 
 # vim: expandtab shiftwidth=4

--- a/S12-methods/fallback.t
+++ b/S12-methods/fallback.t
@@ -75,6 +75,7 @@ is $i(), 'invaught', 'CALL-ME beats FALLBACK';
 
     proto sub target() is me'd {*}
     multi sub target() { 'wrong' }
+    #?rakudo.jvm todo "got 'wrong'"
     is target(), 'In CALL-ME',
         'A CALL-ME mixed into a proto in a trait_mod is called';
 }

--- a/S12-methods/submethods.t
+++ b/S12-methods/submethods.t
@@ -59,6 +59,7 @@ Basic submethod tests. See L<S12/"Submethods">
   is $grtz.baz_blarb,        0, "Baz's submethod blarb was not called";
   is $grtz.grtz_blarb,       1, "Grtz's submethod blarb was called now";
 
+  #?rakudo.jvm 2 todo 'Cannot dispatch to method blarb on Baz because it is not inherited or done by Grtz'
   lives-ok { $grtz.Baz::blarb }, '$obj.Class::submthod';
   is $grtz.baz_blarb,        1, "Baz's submethod blarb was called now";
   is $grtz.grtz_blarb,       1, "Grtz's submethod blarb was not called again";

--- a/integration/advent2012-day21.t
+++ b/integration/advent2012-day21.t
@@ -110,6 +110,7 @@ sub run-harness($code,$bench-name) {
 }
 
 is run-harness($bench1, 'sequence'), $expected-output, 'sequence';
+#?rakudo.jvm todo 'Fails more often than it passes'
 is run-harness($bench2, 'recursive-ternary-hand-cached'), $expected-output, 'recursive-ternary-hand-cached';
 is run-harness($bench3, 'sequence-ternary'), $expected-output, 'sequence-ternary';
 is run-harness($bench4, 'loop'), $expected-output, 'loop';


### PR DESCRIPTION
Some of the fudged tests are new (S06-signature/closure-parameters.t,
S12-methods/fallback.t), or have been modified recently
(S12-construction/destruction.t).

The test in S12-methods/submethods.t is a regression.

The other tests have been flapping for a long time and it seems
better to have them as 'todo'.