### PR TITLE
Added test to exercise sequentially resolved multis (See issue #765)

### DIFF
--- a/S12-subset/multi-sequential.t
+++ b/S12-subset/multi-sequential.t
@@ -11,9 +11,9 @@ Tests the cases where multi-dispatch is resolved sequentially (e.g. ambiguous su
 
 # L<S12/"Types and Subtypes">
 
-plan 1;
+plan 2;
 
-# https://github.com/Raku/roast/issues/765
+# https://github.com/Raku/roast/issues/7651
 group-of 2 => 'ambiguous subset matches resolved sequentially' => {
   # note: godzilla is both a monster and a hero
   subset Monster of Str where { $_ eq any( <godzilla gammera ghidra golem> ) };
@@ -45,3 +45,16 @@ group-of 2 => 'ambiguous subset matches resolved sequentially' => {
         "Testing ambiguous case runs first multi that matches.");
    }
 }
+
+
+group-of 1 => 'negative case' => {
+    multi sub classify (Hero $name) {
+        return "$name is a hero";
+    }
+    throws-like { classify('doris_day') }, Exception,
+    "Testing that disallowed strings throw exceptions.";
+}
+
+
+
+


### PR DESCRIPTION
Added a new test of multi-dispatch with sequential resolution of an ambiguous subset match.
Following a discussion with Jonathan Worthington in https://github.com/rakudo/rakudo/issues/4547

