### PR TITLE
+test (r)index for lists of overlapping needles (Rakudo issue #6104)

### DIFF
--- a/S32-str/index.t
+++ b/S32-str/index.t
@@ -50,6 +50,15 @@ is(index("Ümlaut", "Ü"), 0, "Umlaut");
 
 is("Hello".index("l"), 2, ".index on string");
 
+# Lists of overlapping needles - https://github.com/rakudo/rakudo/issues/6104
+
+is(index("ab", <ab b>), 0, "Second needle contained in the first");
+is(index("ab", <b ab>), 0, "First needle contained in the second");
+is(index("abc", <ab bc>), 0, "Needles with partial overlap (small index first)");
+is(index("abc", <bc ab>), 0, "Needles with partial overlap (large index first)");
+is(index("abcbc", <bc abc>), 0, "First needle contained in the second and occurring twice in str");
+is(index("abccbccbab", <ccbc bccb cbcc bcc bab ccbc>), 1, "Many overlapping needles");
+
 # work on variables
 
 my $a = "word";

--- a/S32-str/rindex.t
+++ b/S32-str/rindex.t
@@ -56,7 +56,7 @@ is(rindex("ab", <ab b>), 1, "Second needle contained in the first");
 is(rindex("abc", <bc ab>), 1, "Needles with partial overlap (large index first)");
 is(rindex("abc", <ab bc>), 1, "Needles with partial overlap (small index first)");
 is(rindex("abcab", <abc ab>), 3, "Second needle contained in the first and occurring twice in str");
-is(rindex("acbc", <cbc ac bc>), 2, "Needles with partial overlap (large index first)");
+is(rindex("acbc", <cbc ac bc>), 2, "Needles with partial and with complete overlap");
 is(rindex("accbabccbccbab", <ccbc bccb ccba cbcc cbba bcc ccba ccbc>), 9, "Many overlapping needles");
 
 # on scalar variable

--- a/S32-str/rindex.t
+++ b/S32-str/rindex.t
@@ -49,6 +49,16 @@ is(rindex("what are these « » unicode characters for ?", "uni"), 19, "over uni
 is("Hello World".rindex("l"), 9, ".rindex on string");
 is("Hello World".rindex(''), 11, ".rindex('') on string gives string length graphemes");
 
+# Lists of overlapping needles - https://github.com/rakudo/rakudo/issues/6104
+
+is(rindex("ab", <b ab>), 1, "First needle contained in the second");
+is(rindex("ab", <ab b>), 1, "Second needle contained in the first");
+is(rindex("abc", <bc ab>), 1, "Needles with partial overlap (large index first)");
+is(rindex("abc", <ab bc>), 1, "Needles with partial overlap (small index first)");
+is(rindex("abcab", <abc ab>), 3, "Second needle contained in the first and occurring twice in str");
+is(rindex("acbc", <cbc ac bc>), 2, "Needles with partial overlap (large index first)");
+is(rindex("accbabccbccbab", <ccbc bccb ccba cbcc cbba bcc ccba ccbc>), 9, "Many overlapping needles");
+
 # on scalar variable
 my $s = "Hello World";
 is(rindex($s, "o"), 7, "rindex on scalar variable");


### PR DESCRIPTION
Wrapping up [Rakudo issue 6104](https://github.com/rakudo/rakudo/issues/6104), add some tests for index & rindex of the form

```
"ab".index: <b ab>
```

(this line of code having wrongly yielded `1` until lizmat's recent fix [1d991f9](https://github.com/rakudo/rakudo/commit/1d991f95fed985a468df385bc744cdcc2b0052ef)).

The tests are
* mostly targeted tests for specific "overlap configurations", and
* one hodgepodge test at the end to catch other cases of wrong behavior.