### PR TITLE
Stop hardcoding the SETTING::OUTER depth in SETTING-6e.t

### DIFF
--- a/S02-names/SETTING-6e.t
+++ b/S02-names/SETTING-6e.t
@@ -1,18 +1,41 @@
 # SETTING::OUTER::OUTER is a revision-specific namespace.
 use v6.e.PREVIEW;
+use MONKEY-SEE-NO-EVAL;
 use Test;
 
-plan 6;
+# SETTING:: in 6.e resolves to a different point in the static chain than
+# in 6.c, so reaching CORE's &not from user code may require zero or more
+# ::OUTER hops. This test asserts that *some* SETTING::(OUTER::)* path
+# resolves to CORE's negating &not (distinct from the local identity
+# shadow below). The number of hops is not part of the assertion: it
+# tracks setting-layer arrangement, which is an implementation detail.
+
+plan 4;
 
 sub not($x) { $x } #OK
-my $setting = 'SETTING::OUTER::OUTER::OUTER::OUTER';
-ok &SETTING::OUTER::OUTER::OUTER::OUTER::not(False), 'SETTING::OUTER::OUTER::OUTER::OUTER:: works';
-ok &::($setting)::not.(False), '::("' ~ $setting ~ '::") works';
 
-ok EVAL('&SETTING::OUTER::OUTER::OUTER::OUTER::not(False)'), 'SETTING::OUTER::OUTER::OUTER::OUTER:: finds eval context';
-ok EVAL('&::($setting)::not(False)'), '::("' ~ $setting ~ '::") finds eval context';
+# Smallest path of shape SETTING::(OUTER::)* whose &not is CORE's negating
+# version, not the identity shadow above.
+my $path;
+for ^20 -> $n {
+    my $candidate = 'SETTING' ~ '::OUTER' x $n;
+    if (try &::($candidate)::not(False)) === True {
+        $path = $candidate;
+        last;
+    }
+}
+
+ok $path.defined,
+    'some SETTING::(OUTER::)* path resolves to CORE &not';
+
+ok &::($path)::not(False),
+    "::('$path') reaches CORE &not from top-level";
+
+ok EVAL("my \$p = '$path'; \&::(\$p)::not(False)"),
+    "::('$path') reaches CORE &not from inside EVAL";
+
 my $f = EVAL('-> $fn { $fn(); }');
-ok $f({ &CALLER::SETTING::OUTER::OUTER::OUTER::OUTER::not(False) }), 'CALLER::SETTING::OUTER::OUTER::OUTER::OUTER:: works';
-ok $f({ &CALLER::($setting)::not(False) }), 'CALLER::' ~ $setting ~ ':: works (ind)';
+ok $f({ &CALLER::($path)::not(False) }),
+    "CALLER::('$path') reaches CORE &not from closure called via EVAL";
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
The original test baked in SETTING::OUTER::OUTER::OUTER::OUTER, which broke once the 6.e PseudoStash adjusted how far past the unit marker SETTING:: lands. Discover the depth at runtime and assert the lookup forms (top-level indirect, indirect inside EVAL, CALLER indirect) rather than a specific OUTER count.

Allows this test to pass against a `RAKUDO_RAKUAST=1`-built rakudo