### PR TITLE
Feed run-with-tty's script stdin from a file handle

### DIFF
--- a/packages/Test-Helpers/lib/Test/Util.rakumod
+++ b/packages/Test-Helpers/lib/Test/Util.rakumod
@@ -396,14 +396,20 @@ sub run-with-tty(
 
     subtest $desc => {
         $path.IO.spurt: $code;
-        given shell :in, :out, :err, $script {
+        # `script`'s standard input must not be the socketpair a Proc
+        # pipe is: on MacOS `script` does a tcgetattr on its standard
+        # input and exits with "Operation not supported on socket" before
+        # ever running the command. A file handle makes the child inherit
+        # a plain file descriptor instead. The file also carries the
+        # ending newline MacOS `script` wants.
+        my $in-fh = make-temp-file(:content("$in\n")).open: :r;
+        given shell :in($in-fh), :out, :err, $script {
             plan 3;
-            # on MacOS, `script` really wants the ending newline...
-            .in.spurt: "$in\n", :close;
             cmp-ok .out.slurp(:close), '~~', $out,    'STDOUT';
             cmp-ok .err.slurp(:close), '~~', $err,    'STDERR';
             cmp-ok .exitcode,  '~~', $status, 'exit code';
         }
+        $in-fh.close;
     }
 }
 


### PR DESCRIPTION
A Proc's stdin pipe is a socketpair on MacOS, where `script` does a tcgetattr on its standard input and exits with "Operation not supported on socket" before running the command at all. The Proc returned by closing the input handle was then sunk, and since the exit code was nonzero the sink threw, aborting the entire test file instead of producing failures a `todo` can cover. Whether the throw happened depended on whether the child had been reaped by close time, which seems to be why files using the helper (S16-io/eof.t, S32-io/out-buffering.t) failed intermittently on all my macs.

Pass `script`'s input as a file handle instead: the child inherits a plain file descriptor, which `script` accepts on all platforms, the input no longer needs a Proc pipe write, and there is no Proc left to sink.